### PR TITLE
Export 2018 04 25

### DIFF
--- a/locales/de/app.po
+++ b/locales/de/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: 2018-04-05 07:31+0000\n"
 "Last-Translator: Michael Köhler <michael.koehler1@gmx.de>\n"
-"Language-Team: de <LL@li.org>\n"
 "Language: de\n"
+"Language-Team: de <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -64,7 +68,9 @@ msgstr "Werbeverfolgung blockieren"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Manche Werbeanzeigen verfolgen Ihre Seitenbesuche, auch wenn Sie nicht auf die Anzeigen klicken"
+msgstr ""
+"Manche Werbeanzeigen verfolgen Ihre Seitenbesuche, auch wenn Sie nicht "
+"auf die Anzeigen klicken"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -72,15 +78,21 @@ msgstr "Analyseverfolgung blockieren"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Damit werden Aktivitäten wie Tippen und Blättern gesammelt, analysiert und ausgewertet"
+msgstr ""
+"Damit werden Aktivitäten wie Tippen und Blättern gesammelt, analysiert "
+"und ausgewertet"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Verfolgung durch soziale Netzwerke blockieren"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Auf Websites eingebettet, um Ihre Besuche zu verfolgen und Funktionen wie Links zum Teilen anzuzeigen"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Auf Websites eingebettet, um Ihre Besuche zu verfolgen und Funktionen wie"
+" Links zum Teilen anzuzeigen"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -167,8 +179,12 @@ msgstr "App zum Öffnen des Links finden"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Anscheinend kann keine der Apps auf Ihrem Gerät diesen Link öffnen. Sie können %1$s verlassen und bei %2$s nach einer App dafür suchen."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Anscheinend kann keine der Apps auf Ihrem Gerät diesen Link öffnen. Sie "
+"können %1$s verlassen und bei %2$s nach einer App dafür suchen."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -192,12 +208,18 @@ msgstr "Verbindung fehlgeschlagen"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        \"<li>Die Website k&#246;nnte vor&#252;bergehend nicht erreichbar sein, versuchen Sie es bitte sp&#228;ter nochmals.</li>\"\\n"
-"        \"<li>\"Wenn Sie auch keine andere Website aufrufen k&#246;nnen, &#252;berpr&#252;fen Sie bitte die Daten- oder WLAN-Verbindung. \"</li>\"\\n      \"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
+"\"<li>Die Website k&#246;nnte vor&#252;bergehend nicht erreichbar sein, "
+"versuchen Sie es bitte sp&#228;ter nochmals.</li>\"\\n        "
+"\"<li>\"Wenn Sie auch keine andere Website aufrufen k&#246;nnen, "
+"&#252;berpr&#252;fen Sie bitte die Daten- oder WLAN-Verbindung. "
+"\"</li>\"\\n      \"</ul>"
 
 msgctxt "error_timeout_title"
 msgid "The connection timed out"
@@ -213,12 +235,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        \"<li>\"Bitte &#252;berpr&#252;fen Sie die Adresse auf Tippfehler, wie\\n          \"<strong>ww</strong>\".example.com statt\\n"
-"          \"<strong>www</strong>.example.com</li>\"\\n        \"<li>\"Wenn Sie auch keine andere Website aufrufen k&#246;nnen, &#252;berpr&#252;fen Sie bitte die Daten- oder WLAN-Verbindung. "
-"\"</li>\"\\n      \"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
+"\"<li>\"Bitte &#252;berpr&#252;fen Sie die Adresse auf Tippfehler, wie\\n"
+"          \"<strong>ww</strong>\".example.com statt\\n          "
+"\"<strong>www</strong>.example.com</li>\"\\n        \"<li>\"Wenn Sie auch"
+" keine andere Website aufrufen k&#246;nnen, &#252;berpr&#252;fen Sie "
+"bitte die Daten- oder WLAN-Verbindung. \"</li>\"\\n      \"</ul>"
 
 msgctxt "error_malformedURI_title"
 msgid "The address isn’t valid"
@@ -227,12 +253,17 @@ msgstr "Fehler: Ungültige Adresse"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>\"Web-Adressen sehen f&#252;r gew&#246;hnlich folgenderma&#223;en aus: \"<strong>http://www.example.com/</strong></li>\"\\n  "
-"\"<li>Bitte stellen Sie sicher, dass Sie nicht den umgekehrten, sondern den einfachen Schr&#228;gstrich verwenden (<strong>/</strong>).</li>\"\\n \"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li"
+">\"Web-Adressen sehen f&#252;r gew&#246;hnlich folgenderma&#223;en aus: "
+"\"<strong>http://www.example.com/</strong></li>\"\\n  \"<li>Bitte stellen"
+" Sie sicher, dass Sie nicht den umgekehrten, sondern den einfachen "
+"Schr&#228;gstrich verwenden (<strong>/</strong>).</li>\"\\n \"</ul>"
 
 msgctxt "error_redirectLoop_title"
 msgid "The page isn’t redirecting properly"
@@ -241,9 +272,13 @@ msgstr "Fehler: Umleitungsfehler"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Dieses Problem kann manchmal auftreten, wenn Cookies deaktiviert oder abgelehnt werden.</li>\" \\n \"</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Dieses Problem kann manchmal auftreten, wenn Cookies deaktiviert "
+"oder abgelehnt werden.</li>\" \\n \"</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
 msgid "The address wasn’t understood"
@@ -252,9 +287,13 @@ msgstr "Adresse nicht erkannt"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Eventuell m&#252;ssen Sie andere Software installieren, um diese Adresse aufrufen zu k&#246;nnen.</li>\"\\n \"</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Eventuell m&#252;ssen Sie andere Software installieren, um diese "
+"Adresse aufrufen zu k&#246;nnen.</li>\"\\n \"</ul>"
 
 msgctxt "error_sslhandshake_title"
 msgid "Secure connection failed"
@@ -263,15 +302,20 @@ msgstr "Fehler: Gesicherte Verbindung fehlgeschlagen"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Das k&#246;nnte ein Problem mit der Konfiguration des Servers sein, oder jemand will sich als dieser Server ausgeben.</li>\"\\n"
-"  \"<li>Wenn Sie mit diesem Server in der Vergangenheit erfolgreich Verbindungen herstellen konnten, ist der Fehler eventuell nur vor&#252;bergehend, und Sie k&#246;nnen es sp&#228;ter erneut "
-"versuchen.</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Das k&#246;nnte ein Problem mit der Konfiguration des Servers sein,"
+" oder jemand will sich als dieser Server ausgeben.</li>\"\\n  \"<li>Wenn "
+"Sie mit diesem Server in der Vergangenheit erfolgreich Verbindungen "
+"herstellen konnten, ist der Fehler eventuell nur vor&#252;bergehend, und "
+"Sie k&#246;nnen es sp&#228;ter erneut versuchen.</li>\\n</ul>"
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -288,15 +332,25 @@ msgstr "Ihre Rechte"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s ist freie und quelloffene Software, die von Mozilla und anderen Mitwirkenden entwickelt wird."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s ist freie und quelloffene Software, die von Mozilla und anderen "
+"Mitwirkenden entwickelt wird."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s steht unter der \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Mozilla Public License</a>\" und anderen Open-Source-Lizenzen.\""
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s steht unter der \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Mozilla Public License</a>\" und anderen Open-Source-"
+"Lizenzen.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -304,18 +358,28 @@ msgstr "\"%1$s steht unter der \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:docum
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"\"Ihnen werden keine Rechte oder Lizenzen an den Markenrechten der Mozilla Foundation oder einer anderen Partei eingeräumt, dazu zählen die Namen und Logos von Mozilla, Firefox oder %1$s. Weitere "
-"Informationen finden Sie \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">hier</a>."
+"\"Ihnen werden keine Rechte oder Lizenzen an den Markenrechten der "
+"Mozilla Foundation oder einer anderen Partei eingeräumt, dazu zählen die "
+"Namen und Logos von Mozilla, Firefox oder %1$s. Weitere Informationen "
+"finden Sie \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">hier</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Sonstiger Quelltext für %1$s steht unter diversen anderen freien und Open-Source-<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Lizenzen</a>."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Sonstiger Quelltext für %1$s steht unter diversen anderen freien und "
+"Open-Source-<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Lizenzen</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -323,24 +387,33 @@ msgstr "Sonstiger Quelltext für %1$s steht unter diversen anderen freien und Op
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s nutzt auch von Disconnect, Inc. angebotene Blockierlisten als separate und unabhängige Werke unter der \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU General "
-"Public License3</a>\", die \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%3$s\">hier</a>\" verfügbar sind.\""
+"\"%1$s nutzt auch von Disconnect, Inc. angebotene Blockierlisten als "
+"separate und unabhängige Werke unter der \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU "
+"General Public License3</a>\", die \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%3$s\">hier</a>\" verfügbar sind.\""
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr "Startseite"
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
 msgstr "Alle Cookies und Websitedaten entfernen"
 
 msgctxt "settings_cookies_dialog_content"
-msgid "Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox for Fire TV. This may sign you out of websites and remove offline web content."
-msgstr "Jetzt leeren löscht alle Cookies und Websitedaten, die Firefox gespeichert hat. Dadurch werden Sie wahrscheinlich von Websites abgemeldet und Offline-Webinhalte werden gelöscht."
+msgid ""
+"Selecting ‘Clear Now’ will clear all cookies and site data stored by "
+"Firefox for Fire TV. This may sign you out of websites and remove offline"
+" web content."
+msgstr ""
+"Jetzt leeren löscht alle Cookies und Websitedaten, die Firefox "
+"gespeichert hat. Dadurch werden Sie wahrscheinlich von Websites "
+"abgemeldet und Offline-Webinhalte werden gelöscht."
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -352,10 +425,14 @@ msgstr "Der Turbo-Modus hilft Ihnen, schneller zu surfen"
 
 msgctxt "onboarding_turbo_mode_body"
 msgid ""
-"Turbo Mode automatically blocks trackers and ads to help get you where you're going faster. If there's a speed bump – like a site that isn't behaving the way you expect – just turn Turbo Mode off."
+"Turbo Mode automatically blocks trackers and ads to help get you where "
+"you're going faster. If there's a speed bump – like a site that isn't "
+"behaving the way you expect – just turn Turbo Mode off."
 msgstr ""
-"Der Turbo-Modus blockiert automatisch Tracker und Anzeigen, damit Sie schneller ans Ziel kommen. Wenn es ein Problem gibt – wie bei einer Website, die sich nicht so verhält, wie Sie es erwarten – "
-"schalten Sie einfach den Turbo-Modus aus."
+"Der Turbo-Modus blockiert automatisch Tracker und Anzeigen, damit Sie "
+"schneller ans Ziel kommen. Wenn es ein Problem gibt – wie bei einer "
+"Website, die sich nicht so verhält, wie Sie es erwarten – schalten Sie "
+"einfach den Turbo-Modus aus."
 
 msgctxt "onboarding_turbo_mode_button_on"
 msgid "Keep Turbo Mode Enabled"
@@ -364,6 +441,13 @@ msgstr "Turbo-Modus aktiviert lassen"
 msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr "Turbo-Modus deaktivieren"
+
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -384,3 +468,63 @@ msgstr "Am Firefox-TV-Startbildschirm angeheftet"
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
 msgstr "Vom Firefox-TV-Startbildschirm entfernt"
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
+msgstr ""
+

--- a/locales/es-ES/app.po
+++ b/locales/es-ES/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: 2018-04-05 09:35+0000\n"
 "Last-Translator: avelper <avelper@mozilla-hispano.org>\n"
-"Language-Team: es_ES <LL@li.org>\n"
 "Language: es_ES\n"
+"Language-Team: es_ES <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -64,7 +68,9 @@ msgstr "Bloquear rastreadores de publicidad"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Algunos anuncios, aunque no accedas a ellos, rastrean tus visitas a páginas web"
+msgstr ""
+"Algunos anuncios, aunque no accedas a ellos, rastrean tus visitas a "
+"páginas web"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -72,15 +78,21 @@ msgstr "Bloquear rastreadores analíticos"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Se utilizan para recopilar, analizar y medir tus actividades, como cuándo seleccionas algo o te deslizas por la página"
+msgstr ""
+"Se utilizan para recopilar, analizar y medir tus actividades, como cuándo"
+" seleccionas algo o te deslizas por la página"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Bloquear rastreadores sociales"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Incorporados en las páginas para rastrear tus visitas y mostrar funcionalidad, como botones para compartir"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Incorporados en las páginas para rastrear tus visitas y mostrar "
+"funcionalidad, como botones para compartir"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -167,8 +179,12 @@ msgstr "Busca una aplicación que pueda abrir este enlace"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ninguna de las aplicaciones de tu dispositivo puede abrir este enlace. Puedes salir de %1$s para buscar en %2$s una aplicación compatible."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ninguna de las aplicaciones de tu dispositivo puede abrir este enlace. "
+"Puedes salir de %1$s para buscar en %2$s una aplicación compatible."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -192,12 +208,17 @@ msgstr "No se puede conectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        \"<li>Puede que el sitio est&#233; ocupado o no est&#233; disponible temporalmente. Vuelve a intentarlo en unos "
-"minutos.</li>\"\\n        \"<li>Si no puedes cargar ninguna p&#225;gina, comprueba la conexi&#243;n de datos o Wi-Fi de tu dispositivo.</li>\"\\n      \"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
+"\"<li>Puede que el sitio est&#233; ocupado o no est&#233; disponible "
+"temporalmente. Vuelve a intentarlo en unos minutos.</li>\"\\n        "
+"\"<li>Si no puedes cargar ninguna p&#225;gina, comprueba la conexi&#243;n"
+" de datos o Wi-Fi de tu dispositivo.</li>\"\\n      \"</ul>"
 
 msgctxt "error_timeout_title"
 msgid "The connection timed out"
@@ -213,12 +234,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        \"<li>\"Comprueba que la direcci&#243;n no tiene ning&#250;n error como\\n          \"<strong>ww</strong>\".example.com en vez "
-"de\\n          \"<strong>www</strong>.example.com</li>\"\\n        \"<li>Si no puedes cargar ninguna p&#225;gina, comprueba la conexi&#243;n de datos o Wi-Fi de tu dispositivo.</li>\"\\n      "
-"\"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
+"\"<li>\"Comprueba que la direcci&#243;n no tiene ning&#250;n error "
+"como\\n          \"<strong>ww</strong>\".example.com en vez de\\n"
+"          \"<strong>www</strong>.example.com</li>\"\\n        \"<li>Si no"
+" puedes cargar ninguna p&#225;gina, comprueba la conexi&#243;n de datos o"
+" Wi-Fi de tu dispositivo.</li>\"\\n      \"</ul>"
 
 msgctxt "error_malformedURI_title"
 msgid "The address isn’t valid"
@@ -227,12 +252,17 @@ msgstr "La dirección no es válida"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>\"Las direcciones web se suelen escribir as&#237;: \"<strong>http://www.example.com/</strong></li>\"\\n  \"<li>Aseg&#250;rate "
-"de usar las barras oblicuas (<strong>/</strong>).</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>\"Las direcciones web se suelen escribir as&#237;: "
+"\"<strong>http://www.example.com/</strong></li>\"\\n  "
+"\"<li>Aseg&#250;rate de usar las barras oblicuas "
+"(<strong>/</strong>).</li>\\n</ul>"
 
 msgctxt "error_redirectLoop_title"
 msgid "The page isn’t redirecting properly"
@@ -241,9 +271,13 @@ msgstr "La página no se está redireccionando adecuadamente"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>A veces, el problema se produce por desactivar o no aceptar el uso de cookies.</li>\\n</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>A "
+"veces, el problema se produce por desactivar o no aceptar el uso de "
+"cookies.</li>\\n</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
 msgid "The address wasn’t understood"
@@ -252,9 +286,13 @@ msgstr "No se entiende la dirección"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Puede que necesites instalar otro software para abrir esta direcci&#243;n.</li>\\n</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Puede que necesites instalar otro software para abrir esta "
+"direcci&#243;n.</li>\\n</ul>"
 
 msgctxt "error_sslhandshake_title"
 msgid "Secure connection failed"
@@ -263,14 +301,20 @@ msgstr "Fallo en la conexión segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Puede que haya un problema con la configuraci&#243;n del servidor o puede\\nque alguien est&#233; intentando suplantar al "
-"servidor.</li>\"\\n  \"<li>Si ya te hab&#237;as conectado antes a este servidor sin problemas, puede que el error\\nsea temporal y puedes intentarlo m&#225;s tarde.</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Puede que haya un problema con la configuraci&#243;n del servidor o"
+" puede\\nque alguien est&#233; intentando suplantar al "
+"servidor.</li>\"\\n  \"<li>Si ya te hab&#237;as conectado antes a este "
+"servidor sin problemas, puede que el error\\nsea temporal y puedes "
+"intentarlo m&#225;s tarde.</li>\\n</ul>"
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -287,15 +331,25 @@ msgstr "Tus derechos"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s es software de código abierto y gratuito, creado por Mozilla y otros colaboradores."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s es software de código abierto y gratuito, creado por Mozilla y otros"
+" colaboradores."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s está disponible de acuerdo con los términos de la \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Licencia p&#250;blica de Mozilla</a>\" y otras licencias de código abierto.\""
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s está disponible de acuerdo con los términos de la \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Licencia p&#250;blica de Mozilla</a>\" y otras licencias de"
+" código abierto.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -303,18 +357,28 @@ msgstr "\"%1$s está disponible de acuerdo con los términos de la \"<a xmlns:xl
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"\"No tienes ningún derecho o licencia sobre las marcas registradas de la Fundación Mozilla ni cualquier otra parte interesada, incluidos los nombres o logos de Mozilla, Firefox o %1$s. \"<a "
-"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Aqu&#237;</a>\" puedes encontrar más información.\""
+"\"No tienes ningún derecho o licencia sobre las marcas registradas de la "
+"Fundación Mozilla ni cualquier otra parte interesada, incluidos los "
+"nombres o logos de Mozilla, Firefox o %1$s. \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Aqu&#237;</a>\" puedes encontrar más información.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "\"Otras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">licencias</a>\" de código abierto y gratuitas también incluyen código fuente adicional para %1$s.\""
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"\"Otras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">licencias</a>\" de código abierto y gratuitas también "
+"incluyen código fuente adicional para %1$s.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -322,24 +386,33 @@ msgstr "\"Otras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s también utiliza las listas de bloqueo de DIsconnect, Inc. como trabajos separados e independientes bajo la \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Licencia "
-"P&#250;blica General de GNU v3</a>\" y que puedes encontrar \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%3$s\">aqu&#237;</a>."
+"\"%1$s también utiliza las listas de bloqueo de DIsconnect, Inc. como "
+"trabajos separados e independientes bajo la \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Licencia P&#250;blica General de GNU v3</a>\" y que puedes "
+"encontrar \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%3$s\">aqu&#237;</a>."
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr "Inicio"
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
 msgstr "Limpiar todas las cookies y datos del sitio"
 
 msgctxt "settings_cookies_dialog_content"
-msgid "Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox for Fire TV. This may sign you out of websites and remove offline web content."
-msgstr "Seleccionar \"Limpiar ahora\" limpiará todas las cookies y datos del sitio guardados por Firefox. Esto puede desconectarle de sitios web y eliminar el contenido web sin conexión."
+msgid ""
+"Selecting ‘Clear Now’ will clear all cookies and site data stored by "
+"Firefox for Fire TV. This may sign you out of websites and remove offline"
+" web content."
+msgstr ""
+"Seleccionar \"Limpiar ahora\" limpiará todas las cookies y datos del "
+"sitio guardados por Firefox. Esto puede desconectarle de sitios web y "
+"eliminar el contenido web sin conexión."
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -351,10 +424,14 @@ msgstr "El modo turbo te ayuda a navegar más rápido"
 
 msgctxt "onboarding_turbo_mode_body"
 msgid ""
-"Turbo Mode automatically blocks trackers and ads to help get you where you're going faster. If there's a speed bump – like a site that isn't behaving the way you expect – just turn Turbo Mode off."
+"Turbo Mode automatically blocks trackers and ads to help get you where "
+"you're going faster. If there's a speed bump – like a site that isn't "
+"behaving the way you expect – just turn Turbo Mode off."
 msgstr ""
-"El modo turbo bloquea automáticamente rastreadores y anuncios para ayudarte a llegar más rápido a donde vas. Si hay un bache de velocidad, como un sitio que no se comporta como esperabas, solo "
-"tienes que desactivar el modo turbo."
+"El modo turbo bloquea automáticamente rastreadores y anuncios para "
+"ayudarte a llegar más rápido a donde vas. Si hay un bache de velocidad, "
+"como un sitio que no se comporta como esperabas, solo tienes que "
+"desactivar el modo turbo."
 
 msgctxt "onboarding_turbo_mode_button_on"
 msgid "Keep Turbo Mode Enabled"
@@ -363,6 +440,13 @@ msgstr "Mantener activado el modo turbo"
 msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr "Desactivar el modo turbo"
+
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -383,3 +467,63 @@ msgstr "FIjar a la pantalla de inicio de Firefox TV"
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
 msgstr "Eliminar de la pantalla de inicio de Firefox TV"
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
+msgstr ""
+

--- a/locales/fr/app.po
+++ b/locales/fr/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: 2018-04-05 15:10+0000\n"
 "Last-Translator: Théo Chevalier <theo.chevalier11@gmail.com>\n"
-"Language-Team: fr <LL@li.org>\n"
 "Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 0) || (n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -64,7 +68,9 @@ msgstr "Bloquer les traqueurs publicitaires"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Certaines publicités pistent vos visites sur les sites, même sans cliquer sur les publicités"
+msgstr ""
+"Certaines publicités pistent vos visites sur les sites, même sans cliquer"
+" sur les publicités"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -72,15 +78,21 @@ msgstr "Bloquer les traqueurs de statistiques"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Ils servent à collecter, analyser et mesurer les actions telles qu’appuyer sur l’écran ou faire défiler la page"
+msgstr ""
+"Ils servent à collecter, analyser et mesurer les actions telles "
+"qu’appuyer sur l’écran ou faire défiler la page"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Bloquer les traqueurs de réseaux sociaux"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Ils sont insérés sur certains sites pour pister vos visites et afficher des fonctionnalités comme des boutons de partage"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Ils sont insérés sur certains sites pour pister vos visites et afficher "
+"des fonctionnalités comme des boutons de partage"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -167,8 +179,13 @@ msgstr "Trouver une application capable d’ouvrir ce lien"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Aucune des applications de votre appareil n’est capable d’ouvrir ce lien. Vous pouvez quitter %1$s pour rechercher dans %2$s une application qui en est capable."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Aucune des applications de votre appareil n’est capable d’ouvrir ce lien."
+" Vous pouvez quitter %1$s pour rechercher dans %2$s une application qui "
+"en est capable."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -192,12 +209,15 @@ msgstr "La connexion a échoué"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul><li>Le site est peut-être temporairement indisponible ou surchargé. Réessayez plus tard ;</li>\\n<li>Si vous n’arrivez à naviguer sur aucun site, vérifiez la connexion données ou Wi-Fi de votre "
-"appareil.</li></ul>"
+"<ul><li>Le site est peut-être temporairement indisponible ou surchargé. "
+"Réessayez plus tard ;</li>\\n<li>Si vous n’arrivez à naviguer sur aucun "
+"site, vérifiez la connexion données ou Wi-Fi de votre appareil.</li></ul>"
 
 msgctxt "error_timeout_title"
 msgid "The connection timed out"
@@ -213,11 +233,15 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul ><li>Veuillez vérifier la syntaxe de l’adresse (saisie de <strong>ww</strong>.example.com au lieu de <strong>www</strong>.example.com par exemple) ;</li>\\n<li>Si vous n’arrivez à naviguer sur "
-"aucun site, vérifiez la connexion données ou Wi-Fi de votre appareil.</li>\\n</ul>"
+"<ul ><li>Veuillez vérifier la syntaxe de l’adresse (saisie de "
+"<strong>ww</strong>.example.com au lieu de "
+"<strong>www</strong>.example.com par exemple) ;</li>\\n<li>Si vous "
+"n’arrivez à naviguer sur aucun site, vérifiez la connexion données ou Wi-"
+"Fi de votre appareil.</li>\\n</ul>"
 
 msgctxt "error_malformedURI_title"
 msgid "The address isn’t valid"
@@ -226,11 +250,15 @@ msgstr "L’adresse n’est pas valide"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
-"<ul><li>La syntaxe des adresses web est généralement <strong>http://www.example.com/</strong> ;</li>\\n<li>Assurez-vous de bien utiliser des barres obliques (c.-à-d. "
+"<ul><li>La syntaxe des adresses web est généralement "
+"<strong>http://www.example.com/</strong> ;</li>\\n<li>Assurez-vous de "
+"bien utiliser des barres obliques (c.-à-d. "
 "<strong>/</strong>).</li>\\n</ul>"
 
 msgctxt "error_redirectLoop_title"
@@ -240,9 +268,12 @@ msgstr "La page n’est pas redirigée correctement"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
-msgstr "<ul ><li>La cause de ce problème peut être la désactivation ou le refus des cookies.</li></ul>"
+msgstr ""
+"<ul ><li>La cause de ce problème peut être la désactivation ou le refus "
+"des cookies.</li></ul>"
 
 msgctxt "error_unsupportedprotocol_title"
 msgid "The address wasn’t understood"
@@ -251,9 +282,12 @@ msgstr "L’adresse n’a pas été reconnue"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
-msgstr "<ul><li>Il est peut-être nécessaire d’installer une autre application pour ouvrir ce type d’adresse.</li></ul>"
+msgstr ""
+"<ul><li>Il est peut-être nécessaire d’installer une autre application "
+"pour ouvrir ce type d’adresse.</li></ul>"
 
 msgctxt "error_sslhandshake_title"
 msgid "Secure connection failed"
@@ -262,14 +296,18 @@ msgstr "Échec de la connexion sécurisée"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
-"<ul><li>Ceci peut être dû à un problème de configuration du serveur ou à une personne essayant d’usurper l’identité du serveur.</li><li>Si vous avez déjà pu vous connecter à ce serveur, l’erreur est"
-" peut-être temporaire et vous pouvez essayer à nouveau plus tard.</li></ul>"
+"<ul><li>Ceci peut être dû à un problème de configuration du serveur ou à "
+"une personne essayant d’usurper l’identité du serveur.</li><li>Si vous "
+"avez déjà pu vous connecter à ce serveur, l’erreur est peut-être "
+"temporaire et vous pouvez essayer à nouveau plus tard.</li></ul>"
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -286,15 +324,23 @@ msgstr "Droits de l’utilisateur"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s est un logiciel libre et ouvert réalisé par Mozilla avec l’aide d’autres contributeurs."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s est un logiciel libre et ouvert réalisé par Mozilla avec l’aide "
+"d’autres contributeurs."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "%1$s est distribué suivant les modalités de la <a  href=\"%2$s\">Mozilla Public License</a> et d’autres licences open source."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"%1$s est distribué suivant les modalités de la <a  href=\"%2$s\">Mozilla "
+"Public License</a> et d’autres licences open source."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -302,18 +348,26 @@ msgstr "%1$s est distribué suivant les modalités de la <a  href=\"%2$s\">Mozil
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"Il ne vous est cédé aucun droit ou licence sur les marques déposées de la Fondation Mozilla ou de tiers, y compris sur les noms et logos de Mozilla, Firefox ou %1$s. Des informations complémentaires"
-" peuvent être consultées <a  href=\"%2$s\">ici</a>."
+"Il ne vous est cédé aucun droit ou licence sur les marques déposées de la"
+" Fondation Mozilla ou de tiers, y compris sur les noms et logos de "
+"Mozilla, Firefox ou %1$s. Des informations complémentaires peuvent être "
+"consultées <a  href=\"%2$s\">ici</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Le code source complémentaire pour %1$s est disponible sous différentes <a  href=\"%2$s\">licences</a> libres et open source."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Le code source complémentaire pour %1$s est disponible sous différentes "
+"<a  href=\"%2$s\">licences</a> libres et open source."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -321,26 +375,31 @@ msgstr "Le code source complémentaire pour %1$s est disponible sous différente
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s utilise aussi des listes de blocage fournies par Disconnect Inc, en tant que créations sous la licence <a  href=\"%2$s\">GNU General Public License v3</a> et qui sont disponibles <a  "
-"href=\"%3$s\">ici</a>."
+"%1$s utilise aussi des listes de blocage fournies par Disconnect Inc, en "
+"tant que créations sous la licence <a  href=\"%2$s\">GNU General Public "
+"License v3</a> et qui sont disponibles <a  href=\"%3$s\">ici</a>."
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr "Accueil"
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
 msgstr "Effacer les cookies et les données de sites"
 
 msgctxt "settings_cookies_dialog_content"
-msgid "Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox for Fire TV. This may sign you out of websites and remove offline web content."
+msgid ""
+"Selecting ‘Clear Now’ will clear all cookies and site data stored by "
+"Firefox for Fire TV. This may sign you out of websites and remove offline"
+" web content."
 msgstr ""
-"En cliquant sur « Effacer maintenant », vous effacerez toutes les données de sites et tous les cookies stockés par Firefox pour Fire TV. Cette action peut vous déconnecter de certains sites et "
-"supprimer du contenu web disponible hors connexion."
+"En cliquant sur « Effacer maintenant », vous effacerez toutes les données"
+" de sites et tous les cookies stockés par Firefox pour Fire TV. Cette "
+"action peut vous déconnecter de certains sites et supprimer du contenu "
+"web disponible hors connexion."
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -352,10 +411,14 @@ msgstr "Le mode turbo vous permet de naviguer plus rapidement"
 
 msgctxt "onboarding_turbo_mode_body"
 msgid ""
-"Turbo Mode automatically blocks trackers and ads to help get you where you're going faster. If there's a speed bump – like a site that isn't behaving the way you expect – just turn Turbo Mode off."
+"Turbo Mode automatically blocks trackers and ads to help get you where "
+"you're going faster. If there's a speed bump – like a site that isn't "
+"behaving the way you expect – just turn Turbo Mode off."
 msgstr ""
-"Le mode turbo bloque automatiquement les traqueurs et les publicités pour que les pages web se chargent plus vite. S’il y a un hic (comme un site web qui ne fonctionne pas comme vous l’espériez), il"
-" vous suffit de désactiver le mode turbo."
+"Le mode turbo bloque automatiquement les traqueurs et les publicités pour"
+" que les pages web se chargent plus vite. S’il y a un hic (comme un site "
+"web qui ne fonctionne pas comme vous l’espériez), il vous suffit de "
+"désactiver le mode turbo."
 
 msgctxt "onboarding_turbo_mode_button_on"
 msgid "Keep Turbo Mode Enabled"
@@ -364,6 +427,13 @@ msgstr "Laisser le mode turbo activé"
 msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr "Désactiver le mode turbo"
+
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -384,3 +454,63 @@ msgstr "Épinglé à l’écran d’accueil Firefox TV"
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
 msgstr "Retiré de l’écran d’accueil Firefox TV"
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
+msgstr ""
+

--- a/locales/it/app.po
+++ b/locales/it/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: 2018-04-05 05:23+0000\n"
 "Last-Translator: Francesco Lodolo <francesco.lodolo@mozillaitalia.org>\n"
-"Language-Team: it <LL@li.org>\n"
 "Language: it\n"
+"Language-Team: it <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -64,7 +68,9 @@ msgstr "Blocca pubblicità traccianti"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Alcuni annunci pubblicitari, senza bisogno di aprirli, sono in grado di tracciare i siti visitati"
+msgstr ""
+"Alcuni annunci pubblicitari, senza bisogno di aprirli, sono in grado di "
+"tracciare i siti visitati"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -72,15 +78,21 @@ msgstr "Blocca traccianti analitici"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Utilizzati per raccogliere, analizzare e misurare attività come tocchi e scorrimenti"
+msgstr ""
+"Utilizzati per raccogliere, analizzare e misurare attività come tocchi e "
+"scorrimenti"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Blocca traccianti social"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Inseriti nei siti per tenere traccia delle visite e fornire funzionalità come i pulsanti di condivisione"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Inseriti nei siti per tenere traccia delle visite e fornire funzionalità "
+"come i pulsanti di condivisione"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -167,8 +179,12 @@ msgstr "Trova un app per aprire il link"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Nessuna delle app sul dispositivo è in grado di aprire questo link. È possibile uscire da %1$s e cercare una app adatta in %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Nessuna delle app sul dispositivo è in grado di aprire questo link. È "
+"possibile uscire da %1$s e cercare una app adatta in %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -192,12 +208,17 @@ msgstr "Connessione non riuscita"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Il sito potrebbe essere non disponibile o sovraccarico. Riprovare fra qualche istante.</li>\"\\n  \"<li>Se non &#232; possibile"
-" caricare alcuna pagina, controllare la connessione dati o Wi-Fi del dispositivo.</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Il"
+" sito potrebbe essere non disponibile o sovraccarico. Riprovare fra "
+"qualche istante.</li>\"\\n  \"<li>Se non &#232; possibile caricare alcuna"
+" pagina, controllare la connessione dati o Wi-Fi del "
+"dispositivo.</li>\\n</ul>"
 
 msgctxt "error_timeout_title"
 msgid "The connection timed out"
@@ -213,11 +234,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>\"Verificare se l\\'indirizzo contiene errori di battitura del tipo \"<strong>ww</strong>\".example.com invece di "
-"\"<strong>www</strong>.example.com</li>\" \\n  \"<li>Se non &#232; possibile caricare alcuna pagina, controllare la connessione dati o Wi-Fi del dispositivo.</li>\\n</ul>\" \""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>\"Verificare se l\\'indirizzo contiene errori di battitura del tipo"
+" \"<strong>ww</strong>\".example.com invece di "
+"\"<strong>www</strong>.example.com</li>\" \\n  \"<li>Se non &#232; "
+"possibile caricare alcuna pagina, controllare la connessione dati o Wi-Fi"
+" del dispositivo.</li>\\n</ul>\" \""
 
 msgctxt "error_malformedURI_title"
 msgid "The address isn’t valid"
@@ -226,12 +252,17 @@ msgstr "L’indirizzo non è valido"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>\"Gli indirizzi internet normalmente si scrivono nella forma \"<strong>http://www.example.com/</strong></li>\"\\n  "
-"\"<li>\"Verificare di aver utilizzato le barre corrette \"<strong>/</strong>.</li>\\n</ul>\" \""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>\"Gli indirizzi internet normalmente si scrivono nella forma "
+"\"<strong>http://www.example.com/</strong></li>\"\\n  \"<li>\"Verificare "
+"di aver utilizzato le barre corrette \"<strong>/</strong>.</li>\\n</ul>\""
+" \""
 
 msgctxt "error_redirectLoop_title"
 msgid "The page isn’t redirecting properly"
@@ -240,9 +271,13 @@ msgstr "Questa pagina non reindirizza in modo corretto"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Questo problema spesso &#232; causato dal blocco o dal rifiuto dei cookie.</li>\\n</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Questo problema spesso &#232; causato dal blocco o dal rifiuto dei "
+"cookie.</li>\\n</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
 msgid "The address wasn’t understood"
@@ -251,9 +286,13 @@ msgstr "Indirizzo non interpretabile"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>&#200; necessario installare del software aggiuntivo per aprire questo indirizzo.</li>\\n</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>&#200; necessario installare del software aggiuntivo per aprire "
+"questo indirizzo.</li>\\n</ul>"
 
 msgctxt "error_sslhandshake_title"
 msgid "Secure connection failed"
@@ -262,14 +301,20 @@ msgstr "Connessione sicura non riuscita"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Potrebbe trattarsi di un problema nella configurazione del server oppure di un tentativo da parte di qualcuno di sostituirsi al"
-" server stesso.</li>\"\\n  \"<li>Se &#232; stato possibile connettersi a questo server in passato, il problema potrebbe essere solo temporaneo. Si consiglia di riprovare in seguito.</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Potrebbe trattarsi di un problema nella configurazione del server "
+"oppure di un tentativo da parte di qualcuno di sostituirsi al server "
+"stesso.</li>\"\\n  \"<li>Se &#232; stato possibile connettersi a questo "
+"server in passato, il problema potrebbe essere solo temporaneo. Si "
+"consiglia di riprovare in seguito.</li>\\n</ul>"
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -286,15 +331,25 @@ msgstr "I tuoi diritti"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s è un software libero e Open Source realizzato da Mozilla e altri collaboratori."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s è un software libero e Open Source realizzato da Mozilla e altri "
+"collaboratori."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s è disponibile nei termini della \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Mozilla Public License</a>\" e di altre licenze Open Source.\""
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s è disponibile nei termini della \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Mozilla Public License</a>\" e di altre licenze Open "
+"Source.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -302,18 +357,29 @@ msgstr "\"%1$s è disponibile nei termini della \"<a xmlns:xliff=\"urn:oasis:nam
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"\"Mozilla non attribuisce all’utente alcun diritto o licenza relativamente all’utilizzo dei marchi registrati da Mozilla Foundation o da altri soggetti, inclusi i nomi Mozilla, Firefox, %1$s e i "
-"logo associati. Ulteriori informazioni sono disponibili in \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">questa pagina</a>."
+"\"Mozilla non attribuisce all’utente alcun diritto o licenza "
+"relativamente all’utilizzo dei marchi registrati da Mozilla Foundation o "
+"da altri soggetti, inclusi i nomi Mozilla, Firefox, %1$s e i logo "
+"associati. Ulteriori informazioni sono disponibili in \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">questa pagina</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "\"Codice sorgente aggiuntivo per %1$s è disponibile nei termini di altre \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">licenze</a>\" libere e Open Source.\""
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"\"Codice sorgente aggiuntivo per %1$s è disponibile nei termini di altre "
+"\"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">licenze</a>\" libere e Open Source.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -321,27 +387,36 @@ msgstr "\"Codice sorgente aggiuntivo per %1$s è disponibile nei termini di altr
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s utilizza un servizio di \"<em xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">blocklist</em>\" fornito da Disconnect, Inc. in qualità di opera aggiuntiva e separata, distribuita nei "
-"termini della \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU General Public License v3</a>\" e disponibile \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"\"%1$s utilizza un servizio di \"<em "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">blocklist</em>\" "
+"fornito da Disconnect, Inc. in qualità di opera aggiuntiva e separata, "
+"distribuita nei termini della \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU "
+"General Public License v3</a>\" e disponibile \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
 "href=\"%3$s\">qui</a>."
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr "Home"
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
 msgstr "Elimina tutti i cookie e i dati dei siti web"
 
 msgctxt "settings_cookies_dialog_content"
-msgid "Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox for Fire TV. This may sign you out of websites and remove offline web content."
+msgid ""
+"Selecting ‘Clear Now’ will clear all cookies and site data stored by "
+"Firefox for Fire TV. This may sign you out of websites and remove offline"
+" web content."
 msgstr ""
-"Selezionando “Elimina adesso” verranno eliminati tutti i cookie e i dati dei siti web salvati in Firefox per Firefox TV. Questo potrebbe disconnettere l’utente da siti web o rimuovere contenuti per "
-"l’utilizzo non in linea."
+"Selezionando “Elimina adesso” verranno eliminati tutti i cookie e i dati "
+"dei siti web salvati in Firefox per Firefox TV. Questo potrebbe "
+"disconnettere l’utente da siti web o rimuovere contenuti per l’utilizzo "
+"non in linea."
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -353,10 +428,14 @@ msgstr "La modalità turbo ti permette di navigare più velocemente"
 
 msgctxt "onboarding_turbo_mode_body"
 msgid ""
-"Turbo Mode automatically blocks trackers and ads to help get you where you're going faster. If there's a speed bump – like a site that isn't behaving the way you expect – just turn Turbo Mode off."
+"Turbo Mode automatically blocks trackers and ads to help get you where "
+"you're going faster. If there's a speed bump – like a site that isn't "
+"behaving the way you expect – just turn Turbo Mode off."
 msgstr ""
-"La modalità turbo blocca in automatico elementi traccianti e pubblicità per caricare le pagine più rapidamente. Se incontri un problema, come un sito che non funziona come dovrebbe, basterà "
-"disattivare la modalità turbo."
+"La modalità turbo blocca in automatico elementi traccianti e pubblicità "
+"per caricare le pagine più rapidamente. Se incontri un problema, come un "
+"sito che non funziona come dovrebbe, basterà disattivare la modalità "
+"turbo."
 
 msgctxt "onboarding_turbo_mode_button_on"
 msgid "Keep Turbo Mode Enabled"
@@ -365,6 +444,13 @@ msgstr "Mantieni attiva modalità turbo"
 msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr "Disattiva modalità turbo"
+
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -385,3 +471,63 @@ msgstr "Fissato alla schermata principale di Firefox TV"
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
 msgstr "Rimosso dalla schermata principale di Firefox TV"
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
+msgstr ""
+

--- a/locales/ja/app.po
+++ b/locales/ja/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: 2018-04-05 04:32+0000\n"
 "Last-Translator: Kohei Yoshino <kohei.yoshino@gmail.com>\n"
-"Language-Team: ja <LL@li.org>\n"
 "Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -79,7 +83,9 @@ msgid "Block social trackers"
 msgstr "ソーシャル追跡をブロック"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
 msgstr "ユーザーの訪問を追跡するためサイトに埋め込まれ、共有ボタンのように表示されます"
 
 msgctxt "preference_privacy_block_content"
@@ -167,7 +173,9 @@ msgstr "リンクを開けるアプリを探す"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "ご使用の端末にはこのリンクを開けるアプリがありません。%1$s を離れて、%2$s で開けるアプリを探してください。"
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -192,12 +200,16 @@ msgstr "正常に接続できませんでした"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li>このサイトが一時的に利用できなくなっていたり、サーバーの負荷が高すぎて接続できなくなっている可能性があります。しばらくしてから再度試してください。</li>\n"
+"        "
+"<li>このサイトが一時的に利用できなくなっていたり、サーバーの負荷が高すぎて接続できなくなっている可能性があります。しばらくしてから再度試してください。</li>"
+"\n"
 "        <li>他のサイトも表示できない場合、端末のデータ接続や Wi-Fi 接続を確認してください。</li>\n"
 "      </ul>"
 
@@ -215,11 +227,13 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul>\n"
-"        <li><strong>www</strong>.example.com を間違えて <strong>ww</strong>.example.com と入力するなど、アドレスを間違って入力していないか確認してください。</li>\n"
+"        <li><strong>www</strong>.example.com を間違えて "
+"<strong>ww</strong>.example.com と入力するなど、アドレスを間違って入力していないか確認してください。</li>\n"
 "        <li>他のサイトも表示できない場合、端末のデータ接続や Wi-Fi 接続を確認してください。</li>\n"
 "      </ul>"
 
@@ -230,8 +244,10 @@ msgstr "アドレスの書式が正しくありません"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -246,7 +262,8 @@ msgstr "ページの自動転送設定が正しくありません"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -260,7 +277,8 @@ msgstr "アドレスのプロトコルが不明です"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul>\n"
@@ -274,9 +292,11 @@ msgstr "安全な接続ができませんでした"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -300,15 +320,21 @@ msgstr "あなたの権利"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
 msgstr "%1$s は Mozilla や他の貢献者によって開発されているフリーでオープンソースのソフトウェアです。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "%1$s は <a href=\"%2$s\">Mozilla Public License</a> やその他オープンソースライセンスの条件に基づいて使用可能となっています。"
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"%1$s は <a href=\"%2$s\">Mozilla Public License</a> "
+"やその他オープンソースライセンスの条件に基づいて使用可能となっています。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -316,16 +342,25 @@ msgstr "%1$s は <a href=\"%2$s\">Mozilla Public License</a> やその他オー�
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
-msgstr "Mozilla、Firefox、%1$s の名称やロゴを含む、Mozilla Foundation および第三者の商標に関するいかなる権利やライセンスもあなたには与えられていません。追加の情報は <a href=\"%2$s\">Mozilla 商標ポリシー</a> をご覧ください。"
+msgstr ""
+"Mozilla、Firefox、%1$s の名称やロゴを含む、Mozilla Foundation "
+"および第三者の商標に関するいかなる権利やライセンスもあなたには与えられていません。追加の情報は <a href=\"%2$s\">Mozilla "
+"商標ポリシー</a> をご覧ください。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "%1$s の追加ソースコードは、様々な他のフリーおよびオープンソースの <a href=\"%2$s\">ライセンス</a> に基いて公開されています。"
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"%1$s の追加ソースコードは、様々な他のフリーおよびオープンソースの <a href=\"%2$s\">ライセンス</a> "
+"に基いて公開されています。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -333,22 +368,29 @@ msgstr "%1$s の追加ソースコードは、様々な他のフリーおよび�
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
-msgstr "%1$s は Disconnect, Inc. により提供されているブロックリストも <a href=\"%2$s\">GNU General Public License v3</a> の下で単独のリソースとして使用しており、それらは <a href=\"%3$s\">こちら</a> から入手可能です。"
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
+msgstr ""
+"%1$s は Disconnect, Inc. により提供されているブロックリストも <a href=\"%2$s\">GNU General "
+"Public License v3</a> の下で単独のリソースとして使用しており、それらは <a href=\"%3$s\">こちら</a> "
+"から入手可能です。"
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr "ホーム"
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
 msgstr "すべての Cookie とサイトデータの消去"
 
 msgctxt "settings_cookies_dialog_content"
-msgid "Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox for Fire TV. This may sign you out of websites and remove offline web content."
-msgstr "[今すぐ消去] を選択すると Firefox for Fire TV に保存されたすべての Cookie とサイトデータが消去されます。ウェブサイトからログアウトし、オフライン作業用のウェブページが削除されます。"
+msgid ""
+"Selecting ‘Clear Now’ will clear all cookies and site data stored by "
+"Firefox for Fire TV. This may sign you out of websites and remove offline"
+" web content."
+msgstr ""
+"[今すぐ消去] を選択すると Firefox for Fire TV に保存されたすべての Cookie "
+"とサイトデータが消去されます。ウェブサイトからログアウトし、オフライン作業用のウェブページが削除されます。"
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -360,8 +402,12 @@ msgstr "ターボモードはより速くブラウズするのに役立ちます
 
 msgctxt "onboarding_turbo_mode_body"
 msgid ""
-"Turbo Mode automatically blocks trackers and ads to help get you where you're going faster. If there's a speed bump – like a site that isn't behaving the way you expect – just turn Turbo Mode off."
-msgstr "ターボモードは自動的にトラッカーと広告をブロックし、より速くブラウズするのを手助けします。 サイトが期待通りに動作しないなど問題が見られる場合は、ターボモードを無効化してください。"
+"Turbo Mode automatically blocks trackers and ads to help get you where "
+"you're going faster. If there's a speed bump – like a site that isn't "
+"behaving the way you expect – just turn Turbo Mode off."
+msgstr ""
+"ターボモードは自動的にトラッカーと広告をブロックし、より速くブラウズするのを手助けします。 "
+"サイトが期待通りに動作しないなど問題が見られる場合は、ターボモードを無効化してください。"
 
 msgctxt "onboarding_turbo_mode_button_on"
 msgid "Keep Turbo Mode Enabled"
@@ -370,6 +416,13 @@ msgstr "ターボモードを有効のままにする"
 msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr "ターボモードを無効にする"
+
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -390,3 +443,63 @@ msgstr "Firefox TV のホーム画面にピン留めしました"
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
 msgstr "Firefox TV のホーム画面から削除しました"
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
+msgstr ""
+

--- a/locales/pt-BR/app.po
+++ b/locales/pt-BR/app.po
@@ -2,23 +2,28 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: 2018-04-12 13:35+0000\n"
 "Last-Translator: Maykon Chagas <mchagas@riseup.net>\n"
-"Language-Team: pt_BR <LL@li.org>\n"
 "Language: pt_BR\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n >= 0 && n <= 2)) && (!((n == 2))))"
+" ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -64,7 +69,9 @@ msgstr "Bloquear rastreadores de anúncio"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Algumas propagandas rastreiam os sites visitados, mesmo se você não clicar na propaganda"
+msgstr ""
+"Algumas propagandas rastreiam os sites visitados, mesmo se você não "
+"clicar na propaganda"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -79,8 +86,12 @@ msgid "Block social trackers"
 msgstr "Bloquear rastreadores sociais"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Incorporados nos sites para rastrear suas visitas e exibir funcionalidades como botões de compartilhamento"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Incorporados nos sites para rastrear suas visitas e exibir "
+"funcionalidades como botões de compartilhamento"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -167,8 +178,12 @@ msgstr "Encontrar um app que pode abrir o link"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Nenhum aplicativo do seu dispositivo consegue abrir este link. Você pode sair do %1$s para pesquisar no %2$s por um aplicativo compatível."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Nenhum aplicativo do seu dispositivo consegue abrir este link. Você pode "
+"sair do %1$s para pesquisar no %2$s por um aplicativo compatível."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -192,12 +207,17 @@ msgstr "Não foi possível conectar"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        \"<li>O site pode estar temporariamente indispon&#237;vel ou ocupado demais. Tente novamente em alguns instantes.</li>\"\\n"
-"        \"<li>Se n&#227;o conseguir carregar nenhuma p&#225;gina, verifique a conex&#227;o de dados ou Wi-Fi do seu dispositivo m&#243;vel.</li>\"\\n      \"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
+"\"<li>O site pode estar temporariamente indispon&#237;vel ou ocupado "
+"demais. Tente novamente em alguns instantes.</li>\"\\n        \"<li>Se "
+"n&#227;o conseguir carregar nenhuma p&#225;gina, verifique a conex&#227;o"
+" de dados ou Wi-Fi do seu dispositivo m&#243;vel.</li>\"\\n      \"</ul>"
 
 msgctxt "error_timeout_title"
 msgid "The connection timed out"
@@ -213,12 +233,17 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        \"<li>\"Verifique se o endere&#231;o cont&#233;m erros de digita&#231;&#227;o, como\\n          "
-"\"<strong>ww</strong>\".example.com ao inv&#233;s de\\n          \"<strong>www</strong>.example.com</li>\"\\n        \"<li>Se n&#227;o conseguir carregar nenhuma p&#225;gina, verifique a "
-"conex&#227;o de dados ou Wi-Fi de seu dispositivo.</li>\"\\n      \"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
+"\"<li>\"Verifique se o endere&#231;o cont&#233;m erros de "
+"digita&#231;&#227;o, como\\n          \"<strong>ww</strong>\".example.com"
+" ao inv&#233;s de\\n          "
+"\"<strong>www</strong>.example.com</li>\"\\n        \"<li>Se n&#227;o "
+"conseguir carregar nenhuma p&#225;gina, verifique a conex&#227;o de dados"
+" ou Wi-Fi de seu dispositivo.</li>\"\\n      \"</ul>"
 
 msgctxt "error_malformedURI_title"
 msgid "The address isn’t valid"
@@ -227,12 +252,16 @@ msgstr "O endereço não é válido"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>\"Os endere&#231;os da Web s&#227;o geralmente escritos como \"<strong>http://www.example.com/</strong></li>\"\\n  \"<li"
-">\"Certifique-se de usar barras obl&#237;quas (ex. \"<strong>/</strong>).</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>\"Os endere&#231;os da Web s&#227;o geralmente escritos como "
+"\"<strong>http://www.example.com/</strong></li>\"\\n  \"<li>\"Certifique-"
+"se de usar barras obl&#237;quas (ex. \"<strong>/</strong>).</li>\\n</ul>"
 
 msgctxt "error_redirectLoop_title"
 msgid "The page isn’t redirecting properly"
@@ -241,9 +270,13 @@ msgstr "A página não está sendo redirecionada corretamente"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Este problema, &#224;s vezes, pode ser causado pela desativa&#231;&#227;o ou recusa em aceitar os cookies.</li>\\n</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Este problema, &#224;s vezes, pode ser causado pela "
+"desativa&#231;&#227;o ou recusa em aceitar os cookies.</li>\\n</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
 msgid "The address wasn’t understood"
@@ -252,9 +285,13 @@ msgstr "O endereço não foi compreendido"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
-msgstr "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Talvez seja necess&#225;rio instalar outro software para abrir esse endere&#231;o.</li>\\n</ul>"
+msgstr ""
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Talvez seja necess&#225;rio instalar outro software para abrir esse"
+" endere&#231;o.</li>\\n</ul>"
 
 msgctxt "error_sslhandshake_title"
 msgid "Secure connection failed"
@@ -263,14 +300,20 @@ msgstr "Falha na conexão segura"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>Isto pode ser um problema com a configura&#231;&#227;o do servidor ou pode ser algu&#233;m tentando se passar pelo "
-"servidor.</li>\"\\n  \"<li>Se voc&#234; se conectou a este servidor com sucesso no passado, o erro pode ser tempor&#225;rio, e voc&#234; pode tentar novamente mais tarde.</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>Isto pode ser um problema com a configura&#231;&#227;o do servidor "
+"ou pode ser algu&#233;m tentando se passar pelo servidor.</li>\"\\n  "
+"\"<li>Se voc&#234; se conectou a este servidor com sucesso no passado, o "
+"erro pode ser tempor&#225;rio, e voc&#234; pode tentar novamente mais "
+"tarde.</li>\\n</ul>"
 
 msgctxt "error_generic_title"
 msgid "Oops"
@@ -287,15 +330,25 @@ msgstr "Seus direitos"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "O %1$s é um software livre e de código aberto feita pela Mozilla e outros contribuidores."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"O %1$s é um software livre e de código aberto feita pela Mozilla e outros"
+" contribuidores."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "O %1$s é disponibilizado de acordo com os termos da <a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Licença Pública da Mozilla</a> e outras licenças de código aberto."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"O %1$s é disponibilizado de acordo com os termos da <a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Licença Pública da Mozilla</a> e outras licenças de código "
+"aberto."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -303,18 +356,28 @@ msgstr "O %1$s é disponibilizado de acordo com os termos da <a xmlns:xliff=\"ur
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"Não lhe são concedidos quaisquer direitos ou licenças sobre marcas registradas da Fundação Mozilla ou de terceiros, incluindo os nomes ou logos da Mozilla, Firefox ou %1$s. Informações adicionais "
-"podem ser encontradas <a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">aqui</a>."
+"Não lhe são concedidos quaisquer direitos ou licenças sobre marcas "
+"registradas da Fundação Mozilla ou de terceiros, incluindo os nomes ou "
+"logos da Mozilla, Firefox ou %1$s. Informações adicionais podem ser "
+"encontradas <a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">aqui</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "\"Código fonte adicionais para o %1$s estão disponíveis sobre várias outras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">licen&#231;as</a>\" livres e de código aberto.\""
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"\"Código fonte adicionais para o %1$s estão disponíveis sobre várias "
+"outras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">licen&#231;as</a>\" livres e de código aberto.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -322,26 +385,35 @@ msgstr "\"Código fonte adicionais para o %1$s estão disponíveis sobre várias
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"O %1$s também utiliza \"<em xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">listas de bloqueios</em>\" disponibilizadas pela Disconnect, Inc. como um trabalho independente disponibilizado "
-"\"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%3$s\">aqui</a>\", sob a \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU General Public License v3</a>."
+"\"O %1$s também utiliza \"<em "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">listas de "
+"bloqueios</em>\" disponibilizadas pela Disconnect, Inc. como um trabalho "
+"independente disponibilizado \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%3$s\">aqui</a>\", sob a \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU "
+"General Public License v3</a>."
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr "Início"
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
 msgstr "Limpar todos os cookies e dados do site"
 
 msgctxt "settings_cookies_dialog_content"
-msgid "Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox for Fire TV. This may sign you out of websites and remove offline web content."
+msgid ""
+"Selecting ‘Clear Now’ will clear all cookies and site data stored by "
+"Firefox for Fire TV. This may sign you out of websites and remove offline"
+" web content."
 msgstr ""
-"Selecionando ´Limpar agora´ irá limpar todos os cookies e dados dos sites que foram armazenados pelo Firefox para Fire TV. Isso poderá desconectar suas contas das páginas web e remover conteúdos "
-"off-line."
+"Selecionando ´Limpar agora´ irá limpar todos os cookies e dados dos sites"
+" que foram armazenados pelo Firefox para Fire TV. Isso poderá desconectar"
+" suas contas das páginas web e remover conteúdos off-line."
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -353,10 +425,14 @@ msgstr "O Modo Turbo auxilia você a navegar mais rápido"
 
 msgctxt "onboarding_turbo_mode_body"
 msgid ""
-"Turbo Mode automatically blocks trackers and ads to help get you where you're going faster. If there's a speed bump – like a site that isn't behaving the way you expect – just turn Turbo Mode off."
+"Turbo Mode automatically blocks trackers and ads to help get you where "
+"you're going faster. If there's a speed bump – like a site that isn't "
+"behaving the way you expect – just turn Turbo Mode off."
 msgstr ""
-"O Modo Turbo bloqueia automaticamente rastreadores e anúncios para ajudá-lo a chegar ao seu destino mais rápido. Se houver algum problema de velocidade - como um site que não está se comportando da "
-"forma que você espera - apenas desligue o Modo Turbo."
+"O Modo Turbo bloqueia automaticamente rastreadores e anúncios para "
+"ajudá-lo a chegar ao seu destino mais rápido. Se houver algum problema de"
+" velocidade - como um site que não está se comportando da forma que você "
+"espera - apenas desligue o Modo Turbo."
 
 msgctxt "onboarding_turbo_mode_button_on"
 msgid "Keep Turbo Mode Enabled"
@@ -365,6 +441,13 @@ msgstr "Manter o Modo Turbo ativado"
 msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr "Desativar Modo Turbo"
+
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -385,3 +468,63 @@ msgstr "Fixado à tela inicial do Firefox TV"
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
 msgstr "Removido da tela inicial do Firefox TV"
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
+msgstr ""
+

--- a/locales/templates/app.pot
+++ b/locales/templates/app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.4.0\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -336,10 +341,6 @@ msgid ""
 msgstr ""
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr ""
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
@@ -375,6 +376,13 @@ msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr ""
 
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
+
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
 msgstr ""
@@ -393,5 +401,64 @@ msgstr ""
 
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
+msgstr ""
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
 msgstr ""
 

--- a/locales/zh-CN/app.po
+++ b/locales/zh-CN/app.po
@@ -2,23 +2,27 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-04-04 16:53-0700\n"
+"POT-Creation-Date: 2018-04-25 18:06-0700\n"
 "PO-Revision-Date: 2018-04-05 00:53+0000\n"
 "Last-Translator: 新垣结衣 <eloli@foxmail.com>\n"
+"Language: zh_Hans_CN\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
-"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
+
+#. The brand name of our partner company, Pocket.
+msgctxt "pocket_brand_name"
+msgid "Pocket"
+msgstr ""
 
 #. Label used for buttons, e.g. in dialogs
 msgctxt "action_cancel"
@@ -79,7 +83,9 @@ msgid "Block social trackers"
 msgstr "拦截社交跟踪器"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
 msgstr "嵌入到网站上从而跟踪您的访问和显示分享按钮"
 
 msgctxt "preference_privacy_block_content"
@@ -167,7 +173,9 @@ msgstr "寻找可以打开此链接的应用"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "您的设备上的应用都不能打开此链接。您可以离开 %1$s，到 %2$s 找找适合的应用。"
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -192,8 +200,10 @@ msgstr "无法连接"
 msgctxt "error_connectionfailure_message"
 msgid ""
 "<ul>\n"
-"        <li>The site could be temporarily unavailable or too busy. Try again in a few moments.</li>\n"
-"        <li>If you are unable to load any pages, check your mobile device’s data or Wi-Fi connection.</li>\n"
+"        <li>The site could be temporarily unavailable or too busy. Try "
+"again in a few moments.</li>\n"
+"        <li>If you are unable to load any pages, check your mobile "
+"device’s data or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
 "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
@@ -216,13 +226,16 @@ msgid ""
 "        <li>Check the address for typing errors such as\n"
 "          <strong>ww</strong>.example.com instead of\n"
 "          <strong>www</strong>.example.com</li>\n"
-"        <li>If you are unable to load any pages, check your device’s data or Wi-Fi connection.</li>\n"
+"        <li>If you are unable to load any pages, check your device’s data"
+" or Wi-Fi connection.</li>\n"
 "      </ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        \"<li>\"&#35831;&#26816;&#26597;&#35813;&#22320;&#22336;&#26159;&#21542;&#36755;&#38169;&#65292;&#27604;&#22914;&#23558;\\n"
-"          \"<strong>www</strong>\".example.com &#38169;&#20889;&#25104; \\n          \"<strong>ww</strong>.example.com</li>\"\\n        "
-"\"<li>&#22914;&#26524;&#24744;&#26080;&#27861;&#36733;&#20837;&#20219;&#20309;&#39029;&#38754;&#65292;&#35831;&#26816;&#26597;&#35813;&#35774;&#22791;&#30340;&#25968;&#25454;&#25110; Wi-Fi "
-"&#36830;&#25509;&#12290;</li>\"\\n      \"</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n        "
+"\"<li>\"&#35831;&#26816;&#26597;&#35813;&#22320;&#22336;&#26159;&#21542;&#36755;&#38169;&#65292;&#27604;&#22914;&#23558;\\n"
+"          \"<strong>www</strong>\".example.com &#38169;&#20889;&#25104; "
+"\\n          \"<strong>ww</strong>.example.com</li>\"\\n        "
+"\"<li>&#22914;&#26524;&#24744;&#26080;&#27861;&#36733;&#20837;&#20219;&#20309;&#39029;&#38754;&#65292;&#35831;&#26816;&#26597;&#35813;&#35774;&#22791;&#30340;&#25968;&#25454;&#25110;"
+" Wi-Fi &#36830;&#25509;&#12290;</li>\"\\n      \"</ul>"
 
 msgctxt "error_malformedURI_title"
 msgid "The address isn’t valid"
@@ -231,12 +244,17 @@ msgstr "地址无效"
 msgctxt "error_malformedURI_message"
 msgid ""
 "<ul>\n"
-"  <li>Web addresses are usually written like <strong>http://www.example.com/</strong></li>\n"
-"  <li>Make sure that you’re using forward slashes (i.e. <strong>/</strong>).</li>\n"
+"  <li>Web addresses are usually written like "
+"<strong>http://www.example.com/</strong></li>\n"
+"  <li>Make sure that you’re using forward slashes (i.e. "
+"<strong>/</strong>).</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>\"&#32593;&#39029;&#22320;&#22336;&#36890;&#24120;&#26684;&#24335;&#20026; \"<strong>http://www.example.com/</strong></li>\"\\n"
-"  \"<li>\"&#35831;&#30830;&#35748;&#24744;&#20351;&#29992;&#30340;&#26159;&#27491;&#26012;&#26464;&#65288;&#21363; \"<strong>/</strong>&#65289;&#12290;</li>\\n</ul>"
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>\"&#32593;&#39029;&#22320;&#22336;&#36890;&#24120;&#26684;&#24335;&#20026;"
+" \"<strong>http://www.example.com/</strong></li>\"\\n  "
+"\"<li>\"&#35831;&#30830;&#35748;&#24744;&#20351;&#29992;&#30340;&#26159;&#27491;&#26012;&#26464;&#65288;&#21363;"
+" \"<strong>/</strong>&#65289;&#12290;</li>\\n</ul>"
 
 msgctxt "error_redirectLoop_title"
 msgid "The page isn’t redirecting properly"
@@ -245,10 +263,13 @@ msgstr "此页面不正确地重定向"
 msgctxt "error_redirectLoop_message"
 msgid ""
 "<ul>\n"
-"  <li>This problem can sometimes be caused by disabling or refusing to accept cookies.</li>\n"
+"  <li>This problem can sometimes be caused by disabling or refusing to "
+"accept cookies.</li>\n"
 "</ul>"
 msgstr ""
-"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  \"<li>&#26377;&#26102;&#20505;&#31105;&#29992;&#25110;&#25298;&#32477;&#25509;&#21463; Cookie "
+"<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
+"\"<li>&#26377;&#26102;&#20505;&#31105;&#29992;&#25110;&#25298;&#32477;&#25509;&#21463;"
+" Cookie "
 "&#20250;&#23548;&#33268;&#27492;&#38382;&#39064;&#12290;</li>\\n</ul>"
 
 msgctxt "error_unsupportedprotocol_title"
@@ -258,7 +279,8 @@ msgstr "无法理解该地址"
 msgctxt "error_unsupportedprotocol_message"
 msgid ""
 "<ul>\n"
-"  <li>You might need to install other software to open this address.</li>\n"
+"  <li>You might need to install other software to open this address.</li>"
+"\n"
 "</ul>"
 msgstr ""
 "<ul xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">\"\\n  "
@@ -271,9 +293,11 @@ msgstr "安全连接失败"
 msgctxt "error_sslhandshake_message"
 msgid ""
 "<ul>\n"
-"  <li>This could be a problem with the server’s configuration, or it could be\n"
+"  <li>This could be a problem with the server’s configuration, or it "
+"could be\n"
 "someone trying to impersonate the server.</li>\n"
-"  <li>If you have connected to this server successfully in the past, the error may\n"
+"  <li>If you have connected to this server successfully in the past, the "
+"error may\n"
 "be temporary, and you can try again later.</li>\n"
 "</ul>"
 msgstr ""
@@ -297,15 +321,22 @@ msgstr "您的权利"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
 msgstr "%1$s 是由 Mozilla 及贡献者制作的一款自由的开源软件。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s 依照 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Mozilla &#20844;&#20849;&#35768;&#21487;&#35777;</a>及其他一些开源许可证向您授权。"
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s 依照 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Mozilla "
+"&#20844;&#20849;&#35768;&#21487;&#35777;</a>及其他一些开源许可证向您授权。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -313,16 +344,26 @@ msgstr "\"%1$s 依照 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\"
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
-msgstr "您没有取得 Mozilla 基金会或任何一方的商标的任何权利或许可，包括 Mozilla、Firefox 和 %1$s 名称或徽标的许可。有关信息请查阅<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">&#27492;&#22788;</a>。"
+msgstr ""
+"您没有取得 Mozilla 基金会或任何一方的商标的任何权利或许可，包括 Mozilla、Firefox 和 %1$s "
+"名称或徽标的许可。有关信息请查阅<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">&#27492;&#22788;</a>。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "%1$s 其他源代码以各类自由和开源<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">&#35768;&#21487;&#35777;</a>开放。"
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"%1$s 其他源代码以各类自由和开源<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">&#35768;&#21487;&#35777;</a>开放。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -330,23 +371,28 @@ msgstr "%1$s 其他源代码以各类自由和开源<a xmlns:xliff=\"urn:oasis:n
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s 还使用 Disconnect 公司提供的阻止列表，它是以 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU &#36890;&#29992;&#20844;&#20849;&#35768;&#21487;&#35777; v3</a>\" 提供的一个独立的作品，可在\"<a "
-"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%3$s\">&#36825;&#37324;</a>找到。"
+"\"%1$s 还使用 Disconnect 公司提供的阻止列表，它是以 \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU "
+"&#36890;&#29992;&#20844;&#20849;&#35768;&#21487;&#35777; v3</a>\" "
+"提供的一个独立的作品，可在\"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%3$s\">&#36825;&#37324;</a>找到。"
 
 #. Firefox for Fire TV     video strings
-msgctxt "menu_drawer_home"
-msgid "Home"
-msgstr "主页"
-
 #. Settings strings
 msgctxt "settings_cookies_dialog_title"
 msgid "Clear all cookies and site data"
 msgstr "清除所有 Cookie 和站点数据"
 
 msgctxt "settings_cookies_dialog_content"
-msgid "Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox for Fire TV. This may sign you out of websites and remove offline web content."
+msgid ""
+"Selecting ‘Clear Now’ will clear all cookies and site data stored by "
+"Firefox for Fire TV. This may sign you out of websites and remove offline"
+" web content."
 msgstr "选择“立即清除”将清除 Firefox 存储的所有 Cookie 和站点数据。这可能使您退出网站的登录，以及删除离线的网站内容。"
 
 msgctxt "turbo_mode"
@@ -359,7 +405,9 @@ msgstr "加速模式下浏览更快更轻巧"
 
 msgctxt "onboarding_turbo_mode_body"
 msgid ""
-"Turbo Mode automatically blocks trackers and ads to help get you where you're going faster. If there's a speed bump – like a site that isn't behaving the way you expect – just turn Turbo Mode off."
+"Turbo Mode automatically blocks trackers and ads to help get you where "
+"you're going faster. If there's a speed bump – like a site that isn't "
+"behaving the way you expect – just turn Turbo Mode off."
 msgstr "加速模式会自动拦截跟踪器与广告，访问网站更迅捷。若您发现网站无法正常工作，请退出加速模式。"
 
 msgctxt "onboarding_turbo_mode_button_on"
@@ -369,6 +417,13 @@ msgstr "保持加速模式启用"
 msgctxt "onboarding_turbo_mode_button_off"
 msgid "Turn Turbo Mode Off"
 msgstr "退出加速模式"
+
+#. Text displayed in a toast to explain to the user how to unpin a tile from
+#. the homescreen.          SELECT refers to a button on the remote: the button
+#. at the center of the 4-way directional navigation.
+msgctxt "homescreen_unpin_tutorial_toast"
+msgid "Press and hold SELECT to unpin from homescreen"
+msgstr ""
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -389,3 +444,63 @@ msgstr "已固定到 Firefox TV 主屏幕"
 msgctxt "notification_unpinned_site"
 msgid "Removed from Firefox TV homescreen"
 msgstr "已从 Firefox TV 主屏幕移除"
+
+#. The title of a tutorial shown to introduce Pocket video recommendations.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_title"
+msgid "Introducing videos recommended by %1$s"
+msgstr ""
+
+#. The description text of a tutorial shown to introduce Pocket video
+#. recommendations.     %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_tutorial_description"
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+
+#. The text on the dismiss button of a tutorial shown to introduce Pocket
+#. video recommendations.
+msgctxt "pocket_home_tutorial_dismiss_button"
+msgid "Ok, got it"
+msgstr ""
+
+#. Spoken to screen reader users when they focus the Pocket tile. Clicking
+#. this tile will take them to the          Pocket video recommendations feed.
+#. %1$s will be replaced with the Pocket brand name.
+#, c-format
+msgctxt "pocket_home_a11y_tile_focused"
+msgid "Video recommendation by %1$s"
+msgstr ""
+
+msgctxt "pocket_video_feed_recommended_videos_title"
+msgid "Recommended videos"
+msgstr ""
+
+#. Text displayed when the Pocket video recommendations feed failed to load.
+msgctxt "pocket_video_feed_failed_to_load"
+msgid "Something went wrong while loading the feed."
+msgstr ""
+
+#. Text displayed on a button to reload the Pocket video recommendations feed
+#. if it failed to load.
+msgctxt "pocket_video_feed_reload_button"
+msgid "Reload"
+msgstr ""
+
+#. Spoken to screen reader users to describe how to navigate on the Pocket
+#. video recommendations feed.
+msgctxt "pocket_video_feed_a11y_navigation"
+msgid "Use left and right to move between videos"
+msgstr ""
+
+#. Spoken to screen reader users when they to describe a Pocket video
+#. recommendation they have focused.     %1$s will be the title of the
+#. recommended video     %2$s will be the source of the video (e.g. YouTube).
+#, c-format
+msgctxt "pocket_video_feed_a11y_feed_item_focused"
+msgid "%1$s on %2$s"
+msgstr ""
+


### PR DESCRIPTION
Remove no longer used home screen strings, preland strings from v3.0 release. The mocks for these strings are available in https://github.com/mozilla-mobile/firefox-tv/issues/759 and additional strings discussion in https://github.com/mozilla-mobile/firefox-tv/issues/829.