### PR TITLE
Export 2019 06 12

### DIFF
--- a/locales/de/app.po
+++ b/locales/de/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: 2019-05-15 18:53+0000\n"
 "Last-Translator: Michael Köhler <michael.koehler1@gmx.de>\n"
-"Language-Team: de <LL@li.org>\n"
 "Language: de\n"
+"Language-Team: de <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. #######################################################################################
 #. ## Put only strings into this file that should be translated. Move all
@@ -83,7 +82,9 @@ msgstr "Werbeverfolgung blockieren"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Manche Werbeanzeigen verfolgen Ihre Seitenbesuche, auch wenn Sie nicht auf die Anzeigen klicken"
+msgstr ""
+"Manche Werbeanzeigen verfolgen Ihre Seitenbesuche, auch wenn Sie nicht "
+"auf die Anzeigen klicken"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -91,15 +92,21 @@ msgstr "Analyseverfolgung blockieren"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Damit werden Aktivitäten wie Tippen und Blättern gesammelt, analysiert und ausgewertet"
+msgstr ""
+"Damit werden Aktivitäten wie Tippen und Blättern gesammelt, analysiert "
+"und ausgewertet"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Verfolgung durch soziale Netzwerke blockieren"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Auf Websites eingebettet, um Ihre Besuche zu verfolgen und Funktionen wie Links zum Teilen anzuzeigen"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Auf Websites eingebettet, um Ihre Besuche zu verfolgen und Funktionen wie"
+" Links zum Teilen anzuzeigen"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -170,8 +177,12 @@ msgstr "App zum Öffnen des Links finden"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Anscheinend kann keine der Apps auf Ihrem Gerät diesen Link öffnen. Sie können %1$s verlassen und bei %2$s nach einer App dafür suchen."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Anscheinend kann keine der Apps auf Ihrem Gerät diesen Link öffnen. Sie "
+"können %1$s verlassen und bei %2$s nach einer App dafür suchen."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -195,15 +206,25 @@ msgstr "Ihre Rechte"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s ist freie und quelloffene Software, die von Mozilla und anderen Mitwirkenden entwickelt wird."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s ist freie und quelloffene Software, die von Mozilla und anderen "
+"Mitwirkenden entwickelt wird."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s steht unter der \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Mozilla Public License</a>\" und anderen Open-Source-Lizenzen.\""
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s steht unter der \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Mozilla Public License</a>\" und anderen Open-Source-"
+"Lizenzen.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -211,18 +232,28 @@ msgstr "\"%1$s steht unter der \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:docum
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"\"Ihnen werden keine Rechte oder Lizenzen an den Markenrechten der Mozilla Foundation oder einer anderen Partei eingeräumt, dazu zählen die Namen und Logos von Mozilla, Firefox oder %1$s. Weitere "
-"Informationen finden Sie \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">hier</a>."
+"\"Ihnen werden keine Rechte oder Lizenzen an den Markenrechten der "
+"Mozilla Foundation oder einer anderen Partei eingeräumt, dazu zählen die "
+"Namen und Logos von Mozilla, Firefox oder %1$s. Weitere Informationen "
+"finden Sie \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">hier</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Sonstiger Quelltext für %1$s steht unter diversen anderen freien und Open-Source-<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Lizenzen</a>."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Sonstiger Quelltext für %1$s steht unter diversen anderen freien und "
+"Open-Source-<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Lizenzen</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -230,10 +261,17 @@ msgstr "Sonstiger Quelltext für %1$s steht unter diversen anderen freien und Op
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s nutzt auch von Disconnect, Inc. angebotene Blockierlisten als separate und unabhängige Werke unter der \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU General "
-"Public License3</a>\", die \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%3$s\">hier</a>\" verfügbar sind.\""
+"\"%1$s nutzt auch von Disconnect, Inc. angebotene Blockierlisten als "
+"separate und unabhängige Werke unter der \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU "
+"General Public License3</a>\", die \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%3$s\">hier</a>\" verfügbar sind.\""
 
 #. Firefox for Fire TV     video strings
 #. Settings strings
@@ -242,8 +280,13 @@ msgid "Clear all cookies and site data"
 msgstr "Alle Cookies und Website-Daten entfernen"
 
 msgctxt "settings_cookies_dialog_content2"
-msgid "This will clear all cookies and site data. Clearing this information may sign you out of websites and delete web content that is stored offline."
-msgstr "Dadurch werden alle Cookies und Website-Daten gelöscht. Wenn Sie diese Daten löschen, werden Sie möglicherweise von Websites abgemeldet und offline gespeicherte Web-Inhalte werden gelöscht."
+msgid ""
+"This will clear all cookies and site data. Clearing this information may "
+"sign you out of websites and delete web content that is stored offline."
+msgstr ""
+"Dadurch werden alle Cookies und Website-Daten gelöscht. Wenn Sie diese "
+"Daten löschen, werden Sie möglicherweise von Websites abgemeldet und "
+"offline gespeicherte Web-Inhalte werden gelöscht."
 
 #. Text on a button that, when pressed, will clear all user data.     Mock:
 #. https://user-images.githubusercontent.com/1721875/47298531-59442f00-d618-11e8-98df-632f74e9ebc3.png
@@ -263,8 +306,12 @@ msgstr "Nutzungsdaten senden"
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
 #, c-format
 msgctxt "settings_telemetry_description"
-msgid "Mozilla strives to collect only what we need to provide and improve %1$s for everyone"
-msgstr "Mozilla ist bestrebt, nur die Informationen zu sammeln, mit denen wir %1$s anbieten und im Sinne aller Nutzer verbessern können"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone"
+msgstr ""
+"Mozilla ist bestrebt, nur die Informationen zu sammeln, mit denen wir "
+"%1$s anbieten und im Sinne aller Nutzer verbessern können"
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -323,6 +370,32 @@ msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
 msgstr "Angeheftete Kacheln"
 
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
+msgstr ""
+
 msgctxt "pin_label"
 msgid "Pin to homescreen"
 msgstr "An Startbildschirm anheften"
@@ -352,8 +425,12 @@ msgstr "Hier kommen von %1$s empfohlene Videos"
 #. recommendations.     %1$s will be replaced with the Pocket brand name.
 #, c-format
 msgctxt "pocket_home_tutorial_description"
-msgid "The most interesting videos on the web. Recommended by %1$s, now part of Mozilla."
-msgstr "Die interessantesten Videos im Internet. Empfohlen von %1$s und jetzt Teil von Mozilla."
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+"Die interessantesten Videos im Internet. Empfohlen von %1$s und jetzt "
+"Teil von Mozilla."
 
 #. The text on the dismiss button of a tutorial shown to introduce Pocket
 #. video recommendations.
@@ -384,7 +461,9 @@ msgstr "Empfohlene Videos"
 #, c-format
 msgctxt "pocket_video_feed_failed_to_load"
 msgid "Hmm. We’re having trouble displaying video recommendations by %1$s."
-msgstr "Hmm. Aktuell gibt es Probleme beim Anzeigen von empfohlenen Videos von %1$s."
+msgstr ""
+"Hmm. Aktuell gibt es Probleme beim Anzeigen von empfohlenen Videos von "
+"%1$s."
 
 #. Text displayed on a button to reload the Pocket video recommendations feed
 #. if it failed to load.
@@ -420,8 +499,12 @@ msgstr "Zu Nicht-Desktop-Version zurückgekehrt"
 #. instructions on how to cast.
 #, c-format, python-format
 msgctxt "youtube_casting_onboarding_toast"
-msgid "Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started."
-msgstr "Spielen Sie YouTube-Videos von Ihrem Handy oder Tablet ab. Öffnen Sie YouTube auf Ihrem Gerät und berühren Sie %s, um zu beginnen."
+msgid ""
+"Cast YouTube videos from your phone or tablet. Open YouTube on your "
+"device and tap %s to get started."
+msgstr ""
+"Spielen Sie YouTube-Videos von Ihrem Handy oder Tablet ab. Öffnen Sie "
+"YouTube auf Ihrem Gerät und berühren Sie %s, um zu beginnen."
 
 #. Content description for the Exit Firefox button.      %1$s will be replaced
 #. with the Firefox brand name.
@@ -454,7 +537,9 @@ msgstr "Drücken Sie die Zurück-Taste, um zurückzukehren"
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay"
 msgid "Press $IMAGE for %1$s Home, search, settings, and more"
-msgstr "Drücken Sie $IMAGE, um die Startseite, Suche, Einstellungen und mehr von %1$s aufzurufen"
+msgstr ""
+"Drücken Sie $IMAGE, um die Startseite, Suche, Einstellungen und mehr von "
+"%1$s aufzurufen"
 
 #. Content description for a hint bar displayed when the browser is open.
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
@@ -463,4 +548,7 @@ msgstr "Drücken Sie $IMAGE, um die Startseite, Suche, Einstellungen und mehr vo
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay_a11y"
 msgid "Press the menu button for %1$s Home, search, settings, and more"
-msgstr "Drücken Sie die Menü-Taste, um die Startseite, Suche, Einstellungen und mehr von %1$s aufzurufen"
+msgstr ""
+"Drücken Sie die Menü-Taste, um die Startseite, Suche, Einstellungen und "
+"mehr von %1$s aufzurufen"
+

--- a/locales/es-ES/app.po
+++ b/locales/es-ES/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: 2019-05-24 17:03+0000\n"
 "Last-Translator: avelper <avelper@mozilla-hispano.org>\n"
-"Language-Team: es_ES <LL@li.org>\n"
 "Language: es_ES\n"
+"Language-Team: es_ES <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. #######################################################################################
 #. ## Put only strings into this file that should be translated. Move all
@@ -83,7 +82,9 @@ msgstr "Bloquear rastreadores de publicidad"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Algunos anuncios, aunque no accedas a ellos, rastrean tus visitas a páginas web"
+msgstr ""
+"Algunos anuncios, aunque no accedas a ellos, rastrean tus visitas a "
+"páginas web"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -91,15 +92,21 @@ msgstr "Bloquear rastreadores analíticos"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Se utilizan para recopilar, analizar y medir tus actividades, como cuándo seleccionas algo o te deslizas por la página"
+msgstr ""
+"Se utilizan para recopilar, analizar y medir tus actividades, como cuándo"
+" seleccionas algo o te deslizas por la página"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Bloquear rastreadores sociales"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Incorporados en las páginas para rastrear tus visitas y mostrar funcionalidad, como botones para compartir"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Incorporados en las páginas para rastrear tus visitas y mostrar "
+"funcionalidad, como botones para compartir"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -170,8 +177,12 @@ msgstr "Busca una aplicación que pueda abrir este enlace"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Ninguna de las aplicaciones de tu dispositivo puede abrir este enlace. Puedes salir de %1$s para buscar en %2$s una aplicación compatible."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Ninguna de las aplicaciones de tu dispositivo puede abrir este enlace. "
+"Puedes salir de %1$s para buscar en %2$s una aplicación compatible."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -195,15 +206,25 @@ msgstr "Tus derechos"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s es software de código abierto y gratuito, creado por Mozilla y otros colaboradores."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s es software de código abierto y gratuito, creado por Mozilla y otros"
+" colaboradores."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s está disponible de acuerdo con los términos de la \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Licencia p&#250;blica de Mozilla</a>\" y otras licencias de código abierto.\""
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s está disponible de acuerdo con los términos de la \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Licencia p&#250;blica de Mozilla</a>\" y otras licencias de"
+" código abierto.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -211,18 +232,28 @@ msgstr "\"%1$s está disponible de acuerdo con los términos de la \"<a xmlns:xl
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"\"No tienes ningún derecho o licencia sobre las marcas registradas de la Fundación Mozilla ni cualquier otra parte interesada, incluidos los nombres o logos de Mozilla, Firefox o %1$s. \"<a "
-"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Aqu&#237;</a>\" puedes encontrar más información.\""
+"\"No tienes ningún derecho o licencia sobre las marcas registradas de la "
+"Fundación Mozilla ni cualquier otra parte interesada, incluidos los "
+"nombres o logos de Mozilla, Firefox o %1$s. \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Aqu&#237;</a>\" puedes encontrar más información.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "\"Otras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">licencias</a>\" de código abierto y gratuitas también incluyen código fuente adicional para %1$s.\""
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"\"Otras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">licencias</a>\" de código abierto y gratuitas también "
+"incluyen código fuente adicional para %1$s.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -230,10 +261,17 @@ msgstr "\"Otras \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s también utiliza las listas de bloqueo de DIsconnect, Inc. como trabajos separados e independientes bajo la \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Licencia "
-"P&#250;blica General de GNU v3</a>\" y que puedes encontrar \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%3$s\">aqu&#237;</a>."
+"\"%1$s también utiliza las listas de bloqueo de DIsconnect, Inc. como "
+"trabajos separados e independientes bajo la \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Licencia P&#250;blica General de GNU v3</a>\" y que puedes "
+"encontrar \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%3$s\">aqu&#237;</a>."
 
 #. Firefox for Fire TV     video strings
 #. Settings strings
@@ -242,8 +280,13 @@ msgid "Clear all cookies and site data"
 msgstr "Limpiar todas las cookies y datos del sitio"
 
 msgctxt "settings_cookies_dialog_content2"
-msgid "This will clear all cookies and site data. Clearing this information may sign you out of websites and delete web content that is stored offline."
-msgstr "Esta acción eliminará todas las cookies y los datos de sitios. Eliminar esta información puede cerrar tu sesión de algunos sitios web y borrar el contenido web almacenado sin conexión."
+msgid ""
+"This will clear all cookies and site data. Clearing this information may "
+"sign you out of websites and delete web content that is stored offline."
+msgstr ""
+"Esta acción eliminará todas las cookies y los datos de sitios. Eliminar "
+"esta información puede cerrar tu sesión de algunos sitios web y borrar el"
+" contenido web almacenado sin conexión."
 
 #. Text on a button that, when pressed, will clear all user data.     Mock:
 #. https://user-images.githubusercontent.com/1721875/47298531-59442f00-d618-11e8-98df-632f74e9ebc3.png
@@ -263,8 +306,12 @@ msgstr "Enviar datos de consumo"
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
 #, c-format
 msgctxt "settings_telemetry_description"
-msgid "Mozilla strives to collect only what we need to provide and improve %1$s for everyone"
-msgstr "Mozilla se esfuerza por recopilar solo lo que necesitamos para proporcionar y mejorar %1$s para todos"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone"
+msgstr ""
+"Mozilla se esfuerza por recopilar solo lo que necesitamos para "
+"proporcionar y mejorar %1$s para todos"
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -323,6 +370,32 @@ msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
 msgstr "Miniaturas fijadas"
 
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
+msgstr ""
+
 msgctxt "pin_label"
 msgid "Pin to homescreen"
 msgstr "Fijar a la pantalla inicio"
@@ -352,8 +425,12 @@ msgstr "Presentando vídeos recomendados por %1$s"
 #. recommendations.     %1$s will be replaced with the Pocket brand name.
 #, c-format
 msgctxt "pocket_home_tutorial_description"
-msgid "The most interesting videos on the web. Recommended by %1$s, now part of Mozilla."
-msgstr "Los videos más interesantes de la web. Recomendado por %1$s, y ahora también parte de Mozilla."
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+"Los videos más interesantes de la web. Recomendado por %1$s, y ahora "
+"también parte de Mozilla."
 
 #. The text on the dismiss button of a tutorial shown to introduce Pocket
 #. video recommendations.
@@ -384,7 +461,9 @@ msgstr "Videos recomendados"
 #, c-format
 msgctxt "pocket_video_feed_failed_to_load"
 msgid "Hmm. We’re having trouble displaying video recommendations by %1$s."
-msgstr "Umm. Estamos teniendo problemas para visualizar los videos recomendados por %1$s."
+msgstr ""
+"Umm. Estamos teniendo problemas para visualizar los videos recomendados "
+"por %1$s."
 
 #. Text displayed on a button to reload the Pocket video recommendations feed
 #. if it failed to load.
@@ -420,8 +499,12 @@ msgstr "Se vuelve a la versión predeterminada"
 #. instructions on how to cast.
 #, c-format, python-format
 msgctxt "youtube_casting_onboarding_toast"
-msgid "Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started."
-msgstr "Transmite vídeos de YouTube desde tu móvil o tableta. Abre YouTube en tu dispositivo y pulsa %s para comenzar."
+msgid ""
+"Cast YouTube videos from your phone or tablet. Open YouTube on your "
+"device and tap %s to get started."
+msgstr ""
+"Transmite vídeos de YouTube desde tu móvil o tableta. Abre YouTube en tu "
+"dispositivo y pulsa %s para comenzar."
 
 #. Content description for the Exit Firefox button.      %1$s will be replaced
 #. with the Firefox brand name.
@@ -463,4 +546,7 @@ msgstr "Presiona $IMAGE para acceder al Inicio, búsqueda, opciones y más de %1
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay_a11y"
 msgid "Press the menu button for %1$s Home, search, settings, and more"
-msgstr "Presiona el botón de menú para acceder al Inicio, búsqueda, opciones y más de %1$s"
+msgstr ""
+"Presiona el botón de menú para acceder al Inicio, búsqueda, opciones y "
+"más de %1$s"
+

--- a/locales/fr/app.po
+++ b/locales/fr/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: 2019-05-30 08:22+0000\n"
 "Last-Translator: Kévin Commaille <zecakeh@pm.me>\n"
-"Language-Team: fr <LL@li.org>\n"
 "Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(((n == 0) || (n == 1)) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. #######################################################################################
 #. ## Put only strings into this file that should be translated. Move all
@@ -83,7 +82,9 @@ msgstr "Bloquer les traqueurs publicitaires"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Certaines publicités pistent vos visites sur les sites, même sans cliquer sur les publicités"
+msgstr ""
+"Certaines publicités pistent vos visites sur les sites, même sans cliquer"
+" sur les publicités"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -91,15 +92,21 @@ msgstr "Bloquer les traqueurs de statistiques"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Ils servent à collecter, analyser et mesurer les actions telles qu’appuyer sur l’écran ou faire défiler la page"
+msgstr ""
+"Ils servent à collecter, analyser et mesurer les actions telles "
+"qu’appuyer sur l’écran ou faire défiler la page"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Bloquer les traqueurs de réseaux sociaux"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Ils sont insérés sur certains sites pour pister vos visites et afficher des fonctionnalités comme des boutons de partage"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Ils sont insérés sur certains sites pour pister vos visites et afficher "
+"des fonctionnalités comme des boutons de partage"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -170,8 +177,13 @@ msgstr "Trouver une application capable d’ouvrir ce lien"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Aucune des applications de votre appareil n’est capable d’ouvrir ce lien. Vous pouvez quitter %1$s pour rechercher dans %2$s une application qui en est capable."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Aucune des applications de votre appareil n’est capable d’ouvrir ce lien."
+" Vous pouvez quitter %1$s pour rechercher dans %2$s une application qui "
+"en est capable."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -195,15 +207,23 @@ msgstr "Droits de l’utilisateur"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s est un logiciel libre et ouvert réalisé par Mozilla avec l’aide d’autres contributeurs."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s est un logiciel libre et ouvert réalisé par Mozilla avec l’aide "
+"d’autres contributeurs."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "%1$s est distribué suivant les modalités de la <a  href=\"%2$s\">Mozilla Public License</a> et d’autres licences open source."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"%1$s est distribué suivant les modalités de la <a  href=\"%2$s\">Mozilla "
+"Public License</a> et d’autres licences open source."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -211,18 +231,26 @@ msgstr "%1$s est distribué suivant les modalités de la <a  href=\"%2$s\">Mozil
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"Il ne vous est cédé aucun droit ou licence sur les marques déposées de la Fondation Mozilla ou de tiers, y compris sur les noms et logos de Mozilla, Firefox ou %1$s. Des informations complémentaires"
-" peuvent être consultées <a  href=\"%2$s\">ici</a>."
+"Il ne vous est cédé aucun droit ou licence sur les marques déposées de la"
+" Fondation Mozilla ou de tiers, y compris sur les noms et logos de "
+"Mozilla, Firefox ou %1$s. Des informations complémentaires peuvent être "
+"consultées <a  href=\"%2$s\">ici</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Le code source complémentaire pour %1$s est disponible sous différentes <a  href=\"%2$s\">licences</a> libres et open source."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Le code source complémentaire pour %1$s est disponible sous différentes "
+"<a  href=\"%2$s\">licences</a> libres et open source."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -230,10 +258,14 @@ msgstr "Le code source complémentaire pour %1$s est disponible sous différente
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"%1$s utilise aussi des listes de blocage fournies par Disconnect Inc, en tant que créations sous la licence <a  href=\"%2$s\">GNU General Public License v3</a> et qui sont disponibles <a  "
-"href=\"%3$s\">ici</a>."
+"%1$s utilise aussi des listes de blocage fournies par Disconnect Inc, en "
+"tant que créations sous la licence <a  href=\"%2$s\">GNU General Public "
+"License v3</a> et qui sont disponibles <a  href=\"%3$s\">ici</a>."
 
 #. Firefox for Fire TV     video strings
 #. Settings strings
@@ -242,8 +274,13 @@ msgid "Clear all cookies and site data"
 msgstr "Effacer les cookies et les données de sites"
 
 msgctxt "settings_cookies_dialog_content2"
-msgid "This will clear all cookies and site data. Clearing this information may sign you out of websites and delete web content that is stored offline."
-msgstr "Cette action effacera l’ensemble des cookies et des données de sites. Effacer ces données peut vous déconnecter de certains sites web et supprimer du contenu web stocké hors connexion."
+msgid ""
+"This will clear all cookies and site data. Clearing this information may "
+"sign you out of websites and delete web content that is stored offline."
+msgstr ""
+"Cette action effacera l’ensemble des cookies et des données de sites. "
+"Effacer ces données peut vous déconnecter de certains sites web et "
+"supprimer du contenu web stocké hors connexion."
 
 #. Text on a button that, when pressed, will clear all user data.     Mock:
 #. https://user-images.githubusercontent.com/1721875/47298531-59442f00-d618-11e8-98df-632f74e9ebc3.png
@@ -263,8 +300,12 @@ msgstr "Envoyer des données d’utilisation"
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
 #, c-format
 msgctxt "settings_telemetry_description"
-msgid "Mozilla strives to collect only what we need to provide and improve %1$s for everyone"
-msgstr "Mozilla veille à collecter uniquement les données nécessaires afin d’offrir et d’améliorer %1$s pour tout le monde"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone"
+msgstr ""
+"Mozilla veille à collecter uniquement les données nécessaires afin "
+"d’offrir et d’améliorer %1$s pour tout le monde"
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -280,7 +321,8 @@ msgid ""
 "If a site doesn’t act the way you expect, try turning it off."
 msgstr ""
 "Le mode turbo bloque automatiquement publicités et traqueurs.\n"
-"Si un site ne fonctionne pas comme vous l’attendiez, essayez de le désactiver."
+"Si un site ne fonctionne pas comme vous l’attendiez, essayez de le "
+"désactiver."
 
 #. Button text for keeping Turbo Mode enabled in onboarding
 msgctxt "button_turbo_mode_keep_enabled2"
@@ -302,7 +344,9 @@ msgstr "Exemple avec le mode turbo activé"
 #. at the center of the 4-way directional navigation.
 msgctxt "homescreen_unpin_tutorial_toast"
 msgid "Press and hold SELECT to unpin from homescreen"
-msgstr "Effectuez un appui long sur SELECT pour détacher cet élément de l’écran d’accueil"
+msgstr ""
+"Effectuez un appui long sur SELECT pour détacher cet élément de l’écran "
+"d’accueil"
 
 msgctxt "homescreen_tile_remove"
 msgid "Remove"
@@ -322,6 +366,32 @@ msgstr "Retirer %1$s des sites épinglés"
 msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
 msgstr "Sites épinglés"
+
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
+msgstr ""
 
 msgctxt "pin_label"
 msgid "Pin to homescreen"
@@ -352,8 +422,12 @@ msgstr "Découvrez des vidéos recommandées par %1$s"
 #. recommendations.     %1$s will be replaced with the Pocket brand name.
 #, c-format
 msgctxt "pocket_home_tutorial_description"
-msgid "The most interesting videos on the web. Recommended by %1$s, now part of Mozilla."
-msgstr "Les vidéos les plus intéressantes du Web. Elles sont recommandées par %1$s, qui fait désormais partie de Mozilla."
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+"Les vidéos les plus intéressantes du Web. Elles sont recommandées par "
+"%1$s, qui fait désormais partie de Mozilla."
 
 #. The text on the dismiss button of a tutorial shown to introduce Pocket
 #. video recommendations.
@@ -384,7 +458,9 @@ msgstr "Vidéos recommandées"
 #, c-format
 msgctxt "pocket_video_feed_failed_to_load"
 msgid "Hmm. We’re having trouble displaying video recommendations by %1$s."
-msgstr "Hum, nous ne parvenons pas à afficher les recommandations de vidéos par %1$s."
+msgstr ""
+"Hum, nous ne parvenons pas à afficher les recommandations de vidéos par "
+"%1$s."
 
 #. Text displayed on a button to reload the Pocket video recommendations feed
 #. if it failed to load.
@@ -420,8 +496,13 @@ msgstr "Retour à la version par défaut"
 #. instructions on how to cast.
 #, c-format, python-format
 msgctxt "youtube_casting_onboarding_toast"
-msgid "Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started."
-msgstr "Diffusez des vidéos YouTube à partir de votre téléphone ou de votre tablette. Ouvrez YouTube sur votre appareil et appuyez sur %s pour commencer."
+msgid ""
+"Cast YouTube videos from your phone or tablet. Open YouTube on your "
+"device and tap %s to get started."
+msgstr ""
+"Diffusez des vidéos YouTube à partir de votre téléphone ou de votre "
+"tablette. Ouvrez YouTube sur votre appareil et appuyez sur %s pour "
+"commencer."
 
 #. Content description for the Exit Firefox button.      %1$s will be replaced
 #. with the Firefox brand name.
@@ -454,7 +535,9 @@ msgstr "Appuyez sur le bouton retour pour revenir"
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay"
 msgid "Press $IMAGE for %1$s Home, search, settings, and more"
-msgstr "Appuyez sur $IMAGE pour atteindre l’accueil, la recherche, les paramètres de %1$s et plus encore"
+msgstr ""
+"Appuyez sur $IMAGE pour atteindre l’accueil, la recherche, les paramètres"
+" de %1$s et plus encore"
 
 #. Content description for a hint bar displayed when the browser is open.
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
@@ -463,4 +546,7 @@ msgstr "Appuyez sur $IMAGE pour atteindre l’accueil, la recherche, les paramè
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay_a11y"
 msgid "Press the menu button for %1$s Home, search, settings, and more"
-msgstr "Appuyez sur le bouton de menu pour atteindre l’accueil, la recherche, les paramètres de %1$s et plus encore"
+msgstr ""
+"Appuyez sur le bouton de menu pour atteindre l’accueil, la recherche, les"
+" paramètres de %1$s et plus encore"
+

--- a/locales/it/app.po
+++ b/locales/it/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: 2019-05-16 05:26+0000\n"
 "Last-Translator: Francesco Lodolo <flod+pontoon@mozilla.com>\n"
-"Language-Team: it <LL@li.org>\n"
 "Language: it\n"
+"Language-Team: it <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n == 1)) && ((0 == 0))) ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. #######################################################################################
 #. ## Put only strings into this file that should be translated. Move all
@@ -83,7 +82,9 @@ msgstr "Blocca pubblicità traccianti"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Alcuni annunci pubblicitari, senza bisogno di aprirli, sono in grado di tracciare i siti visitati"
+msgstr ""
+"Alcuni annunci pubblicitari, senza bisogno di aprirli, sono in grado di "
+"tracciare i siti visitati"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -91,15 +92,21 @@ msgstr "Blocca traccianti analitici"
 
 msgctxt "preference_privacy_block_analytics_summary"
 msgid "Used to collect, analyze and measure activities like tapping and scrolling"
-msgstr "Utilizzati per raccogliere, analizzare e misurare attività come tocchi e scorrimenti"
+msgstr ""
+"Utilizzati per raccogliere, analizzare e misurare attività come tocchi e "
+"scorrimenti"
 
 msgctxt "preference_privacy_block_social"
 msgid "Block social trackers"
 msgstr "Blocca traccianti social"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Inseriti nei siti per tenere traccia delle visite e fornire funzionalità come i pulsanti di condivisione"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Inseriti nei siti per tenere traccia delle visite e fornire funzionalità "
+"come i pulsanti di condivisione"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -170,8 +177,12 @@ msgstr "Trova un app per aprire il link"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Nessuna delle app sul dispositivo è in grado di aprire questo link. È possibile uscire da %1$s e cercare una app adatta in %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Nessuna delle app sul dispositivo è in grado di aprire questo link. È "
+"possibile uscire da %1$s e cercare una app adatta in %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -195,15 +206,25 @@ msgstr "I tuoi diritti"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "%1$s è un software libero e Open Source realizzato da Mozilla e altri collaboratori."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"%1$s è un software libero e Open Source realizzato da Mozilla e altri "
+"collaboratori."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s è disponibile nei termini della \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Mozilla Public License</a>\" e di altre licenze Open Source.\""
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s è disponibile nei termini della \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Mozilla Public License</a>\" e di altre licenze Open "
+"Source.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -211,18 +232,29 @@ msgstr "\"%1$s è disponibile nei termini della \"<a xmlns:xliff=\"urn:oasis:nam
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"\"Mozilla non attribuisce all’utente alcun diritto o licenza relativamente all’utilizzo dei marchi registrati da Mozilla Foundation o da altri soggetti, inclusi i nomi Mozilla, Firefox, %1$s e i "
-"logo associati. Ulteriori informazioni sono disponibili in \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">questa pagina</a>."
+"\"Mozilla non attribuisce all’utente alcun diritto o licenza "
+"relativamente all’utilizzo dei marchi registrati da Mozilla Foundation o "
+"da altri soggetti, inclusi i nomi Mozilla, Firefox, %1$s e i logo "
+"associati. Ulteriori informazioni sono disponibili in \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">questa pagina</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "\"Codice sorgente aggiuntivo per %1$s è disponibile nei termini di altre \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">licenze</a>\" libere e Open Source.\""
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"\"Codice sorgente aggiuntivo per %1$s è disponibile nei termini di altre "
+"\"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">licenze</a>\" libere e Open Source.\""
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -230,10 +262,18 @@ msgstr "\"Codice sorgente aggiuntivo per %1$s è disponibile nei termini di altr
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s utilizza un servizio di \"<em xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">blocklist</em>\" fornito da Disconnect, Inc. in qualità di opera aggiuntiva e separata, distribuita nei "
-"termini della \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU General Public License v3</a>\" e disponibile \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"\"%1$s utilizza un servizio di \"<em "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\">blocklist</em>\" "
+"fornito da Disconnect, Inc. in qualità di opera aggiuntiva e separata, "
+"distribuita nei termini della \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU "
+"General Public License v3</a>\" e disponibile \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
 "href=\"%3$s\">qui</a>."
 
 #. Firefox for Fire TV     video strings
@@ -243,8 +283,13 @@ msgid "Clear all cookies and site data"
 msgstr "Elimina tutti i cookie e i dati dei siti web"
 
 msgctxt "settings_cookies_dialog_content2"
-msgid "This will clear all cookies and site data. Clearing this information may sign you out of websites and delete web content that is stored offline."
-msgstr "Ciò eliminerà tutti i cookie e i dati raccolti. Rimuovere queste informazioni potrebbe causare la disconnessione da siti web e l'eliminazione dei contenuti web salvati offline."
+msgid ""
+"This will clear all cookies and site data. Clearing this information may "
+"sign you out of websites and delete web content that is stored offline."
+msgstr ""
+"Ciò eliminerà tutti i cookie e i dati raccolti. Rimuovere queste "
+"informazioni potrebbe causare la disconnessione da siti web e "
+"l'eliminazione dei contenuti web salvati offline."
 
 #. Text on a button that, when pressed, will clear all user data.     Mock:
 #. https://user-images.githubusercontent.com/1721875/47298531-59442f00-d618-11e8-98df-632f74e9ebc3.png
@@ -264,8 +309,12 @@ msgstr "Invia dati sull’uso"
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
 #, c-format
 msgctxt "settings_telemetry_description"
-msgid "Mozilla strives to collect only what we need to provide and improve %1$s for everyone"
-msgstr "Mozilla si impegna a raccogliere solo i dati necessari a fornire e migliorare %1$s per tutti gli utenti."
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone"
+msgstr ""
+"Mozilla si impegna a raccogliere solo i dati necessari a fornire e "
+"migliorare %1$s per tutti gli utenti."
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -280,7 +329,8 @@ msgid ""
 "Turbo Mode automatically blocks ads and trackers.\n"
 "If a site doesn’t act the way you expect, try turning it off."
 msgstr ""
-"La modalità turbo blocca automaticamente pubblicità ed elementi traccianti.\n"
+"La modalità turbo blocca automaticamente pubblicità ed elementi "
+"traccianti.\n"
 "Se un sito non funziona nel modo previsto, prova a disattivarla."
 
 #. Button text for keeping Turbo Mode enabled in onboarding
@@ -324,6 +374,32 @@ msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
 msgstr "Elementi appuntati"
 
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
+msgstr ""
+
 msgctxt "pin_label"
 msgid "Pin to homescreen"
 msgstr "Appunta alla schermata principale"
@@ -353,8 +429,12 @@ msgstr "Ti presentiamo i video consigliati da %1$s"
 #. recommendations.     %1$s will be replaced with the Pocket brand name.
 #, c-format
 msgctxt "pocket_home_tutorial_description"
-msgid "The most interesting videos on the web. Recommended by %1$s, now part of Mozilla."
-msgstr "I video più interessanti del Web. Consigliati da %1$s, ora parte integrante di Mozilla."
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+"I video più interessanti del Web. Consigliati da %1$s, ora parte "
+"integrante di Mozilla."
 
 #. The text on the dismiss button of a tutorial shown to introduce Pocket
 #. video recommendations.
@@ -385,7 +465,9 @@ msgstr "Video consigliati"
 #, c-format
 msgctxt "pocket_video_feed_failed_to_load"
 msgid "Hmm. We’re having trouble displaying video recommendations by %1$s."
-msgstr "Uhm… Sembra che ci sia un problema con la visualizzazione dei video consigliati da %1$s."
+msgstr ""
+"Uhm… Sembra che ci sia un problema con la visualizzazione dei video "
+"consigliati da %1$s."
 
 #. Text displayed on a button to reload the Pocket video recommendations feed
 #. if it failed to load.
@@ -421,8 +503,12 @@ msgstr "Versione desktop disattivata"
 #. instructions on how to cast.
 #, c-format, python-format
 msgctxt "youtube_casting_onboarding_toast"
-msgid "Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started."
-msgstr "Guarda i video YouTube dal cellulare o dal tablet. Apri YouTube nel dispositivo e tocca %s per iniziare."
+msgid ""
+"Cast YouTube videos from your phone or tablet. Open YouTube on your "
+"device and tap %s to get started."
+msgstr ""
+"Guarda i video YouTube dal cellulare o dal tablet. Apri YouTube nel "
+"dispositivo e tocca %s per iniziare."
 
 #. Content description for the Exit Firefox button.      %1$s will be replaced
 #. with the Firefox brand name.
@@ -455,7 +541,9 @@ msgstr "Per tornare indietro premi il pulsante Indietro"
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay"
 msgid "Press $IMAGE for %1$s Home, search, settings, and more"
-msgstr "Per accedere alla pagina iniziale, ricerca, impostazioni e altro di %1$s, premi $IMAGE"
+msgstr ""
+"Per accedere alla pagina iniziale, ricerca, impostazioni e altro di %1$s,"
+" premi $IMAGE"
 
 #. Content description for a hint bar displayed when the browser is open.
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
@@ -464,4 +552,7 @@ msgstr "Per accedere alla pagina iniziale, ricerca, impostazioni e altro di %1$s
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay_a11y"
 msgid "Press the menu button for %1$s Home, search, settings, and more"
-msgstr "Per accedere alla pagina iniziale, ricerca, impostazioni e altro di %1$s, premi il pulsante Menu"
+msgstr ""
+"Per accedere alla pagina iniziale, ricerca, impostazioni e altro di %1$s,"
+" premi il pulsante Menu"
+

--- a/locales/ja/app.po
+++ b/locales/ja/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: 2019-05-21 01:01+0000\n"
 "Last-Translator: marsf <chimantaea_mirabilis@yahoo.co.jp>\n"
-"Language-Team: ja <LL@li.org>\n"
 "Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. #######################################################################################
 #. ## Put only strings into this file that should be translated. Move all
@@ -98,7 +97,9 @@ msgid "Block social trackers"
 msgstr "ソーシャル追跡をブロック"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
 msgstr "ユーザーの訪問を追跡するためサイトに埋め込まれ、共有ボタンのように表示されます"
 
 msgctxt "preference_privacy_block_content"
@@ -170,7 +171,9 @@ msgstr "リンクを開けるアプリを探す"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "ご使用の端末にはこのリンクを開けるアプリがありません。%1$s を離れて、%2$s で開けるアプリを探してください。"
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -195,15 +198,21 @@ msgstr "あなたの権利"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
 msgstr "%1$s は Mozilla や他の貢献者によって開発されているフリーでオープンソースのソフトウェアです。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "%1$s は <a href=\"%2$s\">Mozilla Public License</a> やその他オープンソースライセンスの条件に基づいて使用可能となっています。"
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"%1$s は <a href=\"%2$s\">Mozilla Public License</a> "
+"やその他オープンソースライセンスの条件に基づいて使用可能となっています。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -211,16 +220,25 @@ msgstr "%1$s は <a href=\"%2$s\">Mozilla Public License</a> やその他オー�
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
-msgstr "Mozilla、Firefox、%1$s の名称やロゴを含む、Mozilla Foundation および第三者の商標に関するいかなる権利やライセンスもあなたには与えられていません。追加の情報は <a href=\"%2$s\">Mozilla 商標ポリシー</a> をご覧ください。"
+msgstr ""
+"Mozilla、Firefox、%1$s の名称やロゴを含む、Mozilla Foundation "
+"および第三者の商標に関するいかなる権利やライセンスもあなたには与えられていません。追加の情報は <a href=\"%2$s\">Mozilla "
+"商標ポリシー</a> をご覧ください。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "%1$s の追加ソースコードは、様々な他のフリーおよびオープンソースの <a href=\"%2$s\">ライセンス</a> に基いて公開されています。"
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"%1$s の追加ソースコードは、様々な他のフリーおよびオープンソースの <a href=\"%2$s\">ライセンス</a> "
+"に基いて公開されています。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -228,8 +246,14 @@ msgstr "%1$s の追加ソースコードは、様々な他のフリーおよび�
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
-msgstr "%1$s は Disconnect, Inc. により提供されているブロックリストも <a href=\"%2$s\">GNU General Public License v3</a> の下で単独のリソースとして使用しており、それらは <a href=\"%3$s\">こちら</a> から入手可能です。"
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
+msgstr ""
+"%1$s は Disconnect, Inc. により提供されているブロックリストも <a href=\"%2$s\">GNU General "
+"Public License v3</a> の下で単独のリソースとして使用しており、それらは <a href=\"%3$s\">こちら</a> "
+"から入手可能です。"
 
 #. Firefox for Fire TV     video strings
 #. Settings strings
@@ -238,8 +262,12 @@ msgid "Clear all cookies and site data"
 msgstr "すべての Cookie とサイトデータの消去"
 
 msgctxt "settings_cookies_dialog_content2"
-msgid "This will clear all cookies and site data. Clearing this information may sign you out of websites and delete web content that is stored offline."
-msgstr "これにより、すべての Cookie とサイトデータが消去され、ウェブサイトからログアウトしたり、オフライン用に保存されているコンテンツが削除されたりする可能性があります。"
+msgid ""
+"This will clear all cookies and site data. Clearing this information may "
+"sign you out of websites and delete web content that is stored offline."
+msgstr ""
+"これにより、すべての Cookie "
+"とサイトデータが消去され、ウェブサイトからログアウトしたり、オフライン用に保存されているコンテンツが削除されたりする可能性があります。"
 
 #. Text on a button that, when pressed, will clear all user data.     Mock:
 #. https://user-images.githubusercontent.com/1721875/47298531-59442f00-d618-11e8-98df-632f74e9ebc3.png
@@ -259,7 +287,9 @@ msgstr "使用状況データを送信"
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
 #, c-format
 msgctxt "settings_telemetry_description"
-msgid "Mozilla strives to collect only what we need to provide and improve %1$s for everyone"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone"
 msgstr "Mozilla は %1$s を皆さんに提供し改善するために必要な情報だけを収集するよう努めています。"
 
 msgctxt "turbo_mode"
@@ -319,6 +349,32 @@ msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
 msgstr "ピン留めしたタイル"
 
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
+msgstr ""
+
 msgctxt "pin_label"
 msgid "Pin to homescreen"
 msgstr "ホーム画面にピン留め"
@@ -348,7 +404,9 @@ msgstr "%1$s からおすすめの動画を紹介します"
 #. recommendations.     %1$s will be replaced with the Pocket brand name.
 #, c-format
 msgctxt "pocket_home_tutorial_description"
-msgid "The most interesting videos on the web. Recommended by %1$s, now part of Mozilla."
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
 msgstr "ウェブ上で一番興味深い動画。Mozilla の一員となった %1$s がおすすめします。"
 
 #. The text on the dismiss button of a tutorial shown to introduce Pocket
@@ -416,7 +474,9 @@ msgstr "デスクトップ版でない表示に戻しました"
 #. instructions on how to cast.
 #, c-format, python-format
 msgctxt "youtube_casting_onboarding_toast"
-msgid "Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started."
+msgid ""
+"Cast YouTube videos from your phone or tablet. Open YouTube on your "
+"device and tap %s to get started."
 msgstr "YouTube 動画をスマートフォンやタブレットからキャスト配信します。開始するには、端末で YouTube を開き、%s をタップしてください。"
 
 #. Content description for the Exit Firefox button.      %1$s will be replaced
@@ -460,3 +520,4 @@ msgstr "$IMAGE を押すと %1$s のホーム画面 (検索、設定など) に�
 msgctxt "hint_press_menu_to_open_overlay_a11y"
 msgid "Press the menu button for %1$s Home, search, settings, and more"
 msgstr "メニューボタンを押すと %1$s のホーム画面 (検索、設定など) に戻ります"
+

--- a/locales/pt-BR/app.po
+++ b/locales/pt-BR/app.po
@@ -2,23 +2,23 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: 2019-05-15 22:00+0000\n"
 "Last-Translator: Marcelo Ghelman <marcelo.ghelman@gmail.com>\n"
-"Language-Team: pt_BR <LL@li.org>\n"
 "Language: pt_BR\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=((((n >= 0 && n <= 2)) && (!((n == 2))))"
+" ? 0 : 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. #######################################################################################
 #. ## Put only strings into this file that should be translated. Move all
@@ -83,7 +83,9 @@ msgstr "Bloquear rastreadores de anúncios"
 
 msgctxt "preference_privacy_block_ads_summary"
 msgid "Some ads track site visits, even if you don’t click the ads"
-msgstr "Algumas propagandas rastreiam visitas a sites, mesmo se você não clicar na propaganda"
+msgstr ""
+"Algumas propagandas rastreiam visitas a sites, mesmo se você não clicar "
+"na propaganda"
 
 msgctxt "preference_privacy_block_analytics"
 msgid "Block analytic trackers"
@@ -98,8 +100,12 @@ msgid "Block social trackers"
 msgstr "Bloquear rastreadores sociais"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
-msgstr "Incorporados nos sites para rastrear suas visitas e exibir funcionalidades como botões de compartilhamento"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
+msgstr ""
+"Incorporados nos sites para rastrear suas visitas e exibir "
+"funcionalidades como botões de compartilhamento"
 
 msgctxt "preference_privacy_block_content"
 msgid "Block other content trackers"
@@ -170,8 +176,12 @@ msgstr "Encontrar um app que consegue abrir o link"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
-msgstr "Nenhum aplicativo instalado no seu dispositivo consegue abrir este link. Você pode sair do %1$s para procurar um aplicativo compatível no %2$s."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
+msgstr ""
+"Nenhum aplicativo instalado no seu dispositivo consegue abrir este link. "
+"Você pode sair do %1$s para procurar um aplicativo compatível no %2$s."
 
 #. This label is shown above a list of apps that can be used to open a given
 #. link
@@ -195,15 +205,25 @@ msgstr "Seus direitos"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
-msgstr "O %1$s é um software livre e de código aberto, feito pela Mozilla e outros colaboradores."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
+msgstr ""
+"O %1$s é um software livre e de código aberto, feito pela Mozilla e "
+"outros colaboradores."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "O %1$s é disponibilizado de acordo com os termos da <a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Licença Pública da Mozilla</a> e outras licenças de código aberto."
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"O %1$s é disponibilizado de acordo com os termos da <a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Licença Pública da Mozilla</a> e outras licenças de código "
+"aberto."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -211,18 +231,26 @@ msgstr "O %1$s é disponibilizado de acordo com os termos da <a xmlns:xliff=\"ur
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
 msgstr ""
-"Não lhe são concedidos quaisquer direitos ou licenças sobre marcas registradas da Fundação Mozilla ou de terceiros, incluindo os nomes ou logos da Mozilla, Firefox ou %1$s. Informações adicionais "
-"podem ser encontradas <a href=\"%2$s\">aqui</a>."
+"Não lhe são concedidos quaisquer direitos ou licenças sobre marcas "
+"registradas da Fundação Mozilla ou de terceiros, incluindo os nomes ou "
+"logos da Mozilla, Firefox ou %1$s. Informações adicionais podem ser "
+"encontradas <a href=\"%2$s\">aqui</a>."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "Códigos fonte adicionais do %1$s estão disponíveis sob várias outras \"<a href=\"%2$s\">licenças</a> livres e de código aberto."
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"Códigos fonte adicionais do %1$s estão disponíveis sob várias outras \"<a"
+" href=\"%2$s\">licenças</a> livres e de código aberto."
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -230,10 +258,15 @@ msgstr "Códigos fonte adicionais do %1$s estão disponíveis sob várias outras
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"O %1$s também usa listas de bloqueio fornecidas pela Disconnect, Inc. como trabalhos separados e independentes, disponibilizados <a href=\"%3$s\">aqui</a>\" sob a \"<a href=\"%2$s\">GNU General "
-"Public License v3</a>."
+"O %1$s também usa listas de bloqueio fornecidas pela Disconnect, Inc. "
+"como trabalhos separados e independentes, disponibilizados <a "
+"href=\"%3$s\">aqui</a>\" sob a \"<a href=\"%2$s\">GNU General Public "
+"License v3</a>."
 
 #. Firefox for Fire TV     video strings
 #. Settings strings
@@ -242,8 +275,13 @@ msgid "Clear all cookies and site data"
 msgstr "Limpar todos os cookies e dados do site"
 
 msgctxt "settings_cookies_dialog_content2"
-msgid "This will clear all cookies and site data. Clearing this information may sign you out of websites and delete web content that is stored offline."
-msgstr "Está ação limpará todos os cookies e dados de sites. Limpar essas informações pode finalizar sessões de sites e apagar conteúdo da web armazenado localmente."
+msgid ""
+"This will clear all cookies and site data. Clearing this information may "
+"sign you out of websites and delete web content that is stored offline."
+msgstr ""
+"Está ação limpará todos os cookies e dados de sites. Limpar essas "
+"informações pode finalizar sessões de sites e apagar conteúdo da web "
+"armazenado localmente."
 
 #. Text on a button that, when pressed, will clear all user data.     Mock:
 #. https://user-images.githubusercontent.com/1721875/47298531-59442f00-d618-11e8-98df-632f74e9ebc3.png
@@ -263,8 +301,12 @@ msgstr "Enviar dados de uso"
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
 #, c-format
 msgctxt "settings_telemetry_description"
-msgid "Mozilla strives to collect only what we need to provide and improve %1$s for everyone"
-msgstr "A Mozilla se empenha em coletar somente o necessário para fornecer e melhorar o %1$s para todos."
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone"
+msgstr ""
+"A Mozilla se empenha em coletar somente o necessário para fornecer e "
+"melhorar o %1$s para todos."
 
 msgctxt "turbo_mode"
 msgid "Turbo Mode"
@@ -280,7 +322,8 @@ msgid ""
 "If a site doesn’t act the way you expect, try turning it off."
 msgstr ""
 "O modo turbo bloqueia anúncios e rastreadores automaticamente.\n"
-"Se um site não agir da forma que você espera, experimente desativar o modo turbo."
+"Se um site não agir da forma que você espera, experimente desativar o "
+"modo turbo."
 
 #. Button text for keeping Turbo Mode enabled in onboarding
 msgctxt "button_turbo_mode_keep_enabled2"
@@ -323,6 +366,32 @@ msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
 msgstr "Quadros fixados"
 
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
+msgstr ""
+
 msgctxt "pin_label"
 msgid "Pin to homescreen"
 msgstr "Fixar na tela inicial"
@@ -352,8 +421,12 @@ msgstr "Apresentação de vídeos recomendados pelo %1$s"
 #. recommendations.     %1$s will be replaced with the Pocket brand name.
 #, c-format
 msgctxt "pocket_home_tutorial_description"
-msgid "The most interesting videos on the web. Recommended by %1$s, now part of Mozilla."
-msgstr "Os vídeos mais interessantes da internet. Recomendados pelo %1$s, agora parte da Mozilla."
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
+msgstr ""
+"Os vídeos mais interessantes da internet. Recomendados pelo %1$s, agora "
+"parte da Mozilla."
 
 #. The text on the dismiss button of a tutorial shown to introduce Pocket
 #. video recommendations.
@@ -420,8 +493,12 @@ msgstr "Retornou para a versão padrão"
 #. instructions on how to cast.
 #, c-format, python-format
 msgctxt "youtube_casting_onboarding_toast"
-msgid "Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started."
-msgstr "Transmita vídeos do YouTube a partir do seu celular ou tablet. Abra o YouTube no seu dispositivo e toque em %s para começar."
+msgid ""
+"Cast YouTube videos from your phone or tablet. Open YouTube on your "
+"device and tap %s to get started."
+msgstr ""
+"Transmita vídeos do YouTube a partir do seu celular ou tablet. Abra o "
+"YouTube no seu dispositivo e toque em %s para começar."
 
 #. Content description for the Exit Firefox button.      %1$s will be replaced
 #. with the Firefox brand name.
@@ -454,7 +531,9 @@ msgstr "Pressione o botão de voltar para retornar"
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay"
 msgid "Press $IMAGE for %1$s Home, search, settings, and more"
-msgstr "Pressione $IMAGE para página inicial do %1$s, pesquisa, configurações, etc."
+msgstr ""
+"Pressione $IMAGE para página inicial do %1$s, pesquisa, configurações, "
+"etc."
 
 #. Content description for a hint bar displayed when the browser is open.
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
@@ -463,4 +542,7 @@ msgstr "Pressione $IMAGE para página inicial do %1$s, pesquisa, configurações
 #, c-format
 msgctxt "hint_press_menu_to_open_overlay_a11y"
 msgid "Press the menu button for %1$s Home, search, settings, and more"
-msgstr "Pressione o botão de menu para ir para a página inicial do %1$s, pesquisa, configurações, etc."
+msgstr ""
+"Pressione o botão de menu para ir para a página inicial do %1$s, "
+"pesquisa, configurações, etc."
+

--- a/locales/templates/app.pot
+++ b/locales/templates/app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -331,6 +331,32 @@ msgstr ""
 #. https://github.com/mozilla-mobile/firefox-tv/issues/1630 for channel mocks
 msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
+msgstr ""
+
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
 msgstr ""
 
 msgctxt "pin_label"

--- a/locales/zh-CN/app.po
+++ b/locales/zh-CN/app.po
@@ -2,23 +2,22 @@
 # Copyright (C) 2018 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-05-15 13:46-0400\n"
+"POT-Creation-Date: 2019-06-12 11:24-0700\n"
 "PO-Revision-Date: 2019-05-16 01:08+0000\n"
 "Last-Translator: passionforlife <eloli@foxmail.com>\n"
+"Language: zh_Hans_CN\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
-"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=(0)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.4.0\n"
-"X-Generator: Pontoon\n"
 
 #. #######################################################################################
 #. ## Put only strings into this file that should be translated. Move all
@@ -98,7 +97,9 @@ msgid "Block social trackers"
 msgstr "拦截社交跟踪器"
 
 msgctxt "preference_privacy_block_social_summary"
-msgid "Embedded on sites to track your visits and to display functionality like share buttons"
+msgid ""
+"Embedded on sites to track your visits and to display functionality like "
+"share buttons"
 msgstr "嵌入到网站上从而跟踪您的访问和显示分享按钮"
 
 msgctxt "preference_privacy_block_content"
@@ -170,7 +171,9 @@ msgstr "寻找可以打开此链接的应用"
 #. Google Play).
 #, c-format
 msgctxt "external_app_prompt_no_app"
-msgid "None of the apps on your device are able to open this link. You can leave %1$s to search %2$s for an app that can."
+msgid ""
+"None of the apps on your device are able to open this link. You can leave"
+" %1$s to search %2$s for an app that can."
 msgstr "您的设备上的应用都不能打开此链接。您可以离开 %1$s，到 %2$s 找找适合的应用。"
 
 #. This label is shown above a list of apps that can be used to open a given
@@ -195,15 +198,22 @@ msgstr "您的权利"
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)
 msgctxt "your_rights_content1"
-msgid "%1$s is free and open source software made by Mozilla and other contributors."
+msgid ""
+"%1$s is free and open source software made by Mozilla and other "
+"contributors."
 msgstr "%1$s 是由 Mozilla 及贡献者制作的一款自由的开源软件。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the MPL (e.g. https://www.mozilla.org/en-US/MPL/)
 msgctxt "your_rights_content2"
-msgid "%1$s is made available to you under the terms of the <a href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
-msgstr "\"%1$s 依照 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">Mozilla &#20844;&#20849;&#35768;&#21487;&#35777;</a>及其他一些开源许可证向您授权。"
+msgid ""
+"%1$s is made available to you under the terms of the <a "
+"href=\"%2$s\">Mozilla Public License</a> and other open source licenses."
+msgstr ""
+"\"%1$s 依照 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">Mozilla "
+"&#20844;&#20849;&#35768;&#21487;&#35777;</a>及其他一些开源许可证向您授权。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -211,16 +221,26 @@ msgstr "\"%1$s 依照 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\"
 #. https://www.mozilla.org/foundation/trademarks/policy/)
 msgctxt "your_rights_content3"
 msgid ""
-"You are not granted any rights or licenses to the trademarks of the Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s names or logos. Additional information may be found <a "
+"You are not granted any rights or licenses to the trademarks of the "
+"Mozilla Foundation or any party, including the Mozilla, Firefox or %1$s "
+"names or logos. Additional information may be found <a "
 "href=\"%2$s\">here</a>."
-msgstr "您没有取得 Mozilla 基金会或任何一方的商标的任何权利或许可，包括 Mozilla、Firefox 和 %1$s 名称或徽标的许可。有关信息请查阅<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">&#27492;&#22788;</a>。"
+msgstr ""
+"您没有取得 Mozilla 基金会或任何一方的商标的任何权利或许可，包括 Mozilla、Firefox 和 %1$s "
+"名称或徽标的许可。有关信息请查阅<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">&#27492;&#22788;</a>。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
 #. URL linking to the list of licenses used by the dependencies.
 msgctxt "your_rights_content4"
-msgid "Additional source code for %1$s is available under various other free and open source <a href=\"%2$s\">licenses</a>."
-msgstr "%1$s 其他源代码以各类自由和开源<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">&#35768;&#21487;&#35777;</a>开放。"
+msgid ""
+"Additional source code for %1$s is available under various other free and"
+" open source <a href=\"%2$s\">licenses</a>."
+msgstr ""
+"%1$s 其他源代码以各类自由和开源<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%2$s\">&#35768;&#21487;&#35777;</a>开放。"
 
 #. Text shown in the "Your rights" screen.     %1$s will be replaced with the
 #. name of the app (e.g. Firefox for Fire TV)     %2$s will be replaced with a
@@ -228,10 +248,16 @@ msgstr "%1$s 其他源代码以各类自由和开源<a xmlns:xliff=\"urn:oasis:n
 #. tracking protection wiki page (e.g.
 #. https://wiki.mozilla.org/Security/Tracking_protection#Lists)
 msgctxt "your_rights_content5"
-msgid "%1$s also uses blocklists provided by Disconnect, Inc. as separate and independent works under the <a href=\"%2$s\">GNU General Public License v3</a>, and available <a href=\"%3$s\">here</a>."
+msgid ""
+"%1$s also uses blocklists provided by Disconnect, Inc. as separate and "
+"independent works under the <a href=\"%2$s\">GNU General Public License "
+"v3</a>, and available <a href=\"%3$s\">here</a>."
 msgstr ""
-"\"%1$s 还使用 Disconnect 公司提供的阻止列表，它是以 \"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU &#36890;&#29992;&#20844;&#20849;&#35768;&#21487;&#35777; v3</a>\" 提供的一个独立的作品，可在\"<a "
-"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%3$s\">&#36825;&#37324;</a>找到。"
+"\"%1$s 还使用 Disconnect 公司提供的阻止列表，它是以 \"<a "
+"xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" href=\"%2$s\">GNU "
+"&#36890;&#29992;&#20844;&#20849;&#35768;&#21487;&#35777; v3</a>\" "
+"提供的一个独立的作品，可在\"<a xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" "
+"href=\"%3$s\">&#36825;&#37324;</a>找到。"
 
 #. Firefox for Fire TV     video strings
 #. Settings strings
@@ -240,7 +266,9 @@ msgid "Clear all cookies and site data"
 msgstr "清除所有 Cookie 和站点数据"
 
 msgctxt "settings_cookies_dialog_content2"
-msgid "This will clear all cookies and site data. Clearing this information may sign you out of websites and delete web content that is stored offline."
+msgid ""
+"This will clear all cookies and site data. Clearing this information may "
+"sign you out of websites and delete web content that is stored offline."
 msgstr "这将清除所有 Cookie 和网站数据。清除此信息可能会使您退出网站登录并删除存储的离线 Web 内容。"
 
 #. Text on a button that, when pressed, will clear all user data.     Mock:
@@ -261,7 +289,9 @@ msgstr "发送使用统计"
 #. %1$s will be replaced with the name of the app (e.g. Firefox for Fire TV)
 #, c-format
 msgctxt "settings_telemetry_description"
-msgid "Mozilla strives to collect only what we need to provide and improve %1$s for everyone"
+msgid ""
+"Mozilla strives to collect only what we need to provide and improve %1$s "
+"for everyone"
 msgstr "Mozilla 坚持仅收集为大众提供和改进 %1$s 所必需的数据"
 
 msgctxt "turbo_mode"
@@ -321,6 +351,32 @@ msgctxt "pinned_tile_channel_title"
 msgid "Pinned Tiles"
 msgstr "已固定的磁贴"
 
+#. Title text displayed above the news tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "news_channel_title"
+msgid "News & Politics"
+msgstr ""
+
+#. Title text displayed above the sports tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "sports_channel_title"
+msgid "Sports"
+msgstr ""
+
+#. Title text displayed above the music tile channel. Channels are a
+#. collection of links     to commonly used sites that are bundled with the
+#. app.
+msgctxt "music_channel_title"
+msgid "Music"
+msgstr ""
+
+#. Title text displayed above the food tile channel. Channels are a collection
+#. of links     to commonly used sites that are bundled with the app.
+msgctxt "food_channel_title"
+msgid "Food"
+msgstr ""
+
 msgctxt "pin_label"
 msgid "Pin to homescreen"
 msgstr "固定到主屏幕"
@@ -350,7 +406,9 @@ msgstr "介绍由“%1$s”推荐的视频"
 #. recommendations.     %1$s will be replaced with the Pocket brand name.
 #, c-format
 msgctxt "pocket_home_tutorial_description"
-msgid "The most interesting videos on the web. Recommended by %1$s, now part of Mozilla."
+msgid ""
+"The most interesting videos on the web. Recommended by %1$s, now part of "
+"Mozilla."
 msgstr "网络上最有趣的视频。由 Mozilla 旗下 %1$s 为您推荐。"
 
 #. The text on the dismiss button of a tutorial shown to introduce Pocket
@@ -418,7 +476,9 @@ msgstr "返回非桌面版"
 #. instructions on how to cast.
 #, c-format, python-format
 msgctxt "youtube_casting_onboarding_toast"
-msgid "Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started."
+msgid ""
+"Cast YouTube videos from your phone or tablet. Open YouTube on your "
+"device and tap %s to get started."
 msgstr "用您的手机或平板电脑投屏 YouTube 视频。在您的设备上打开 YouTube，然后点按 %s 即可开始使用。"
 
 #. Content description for the Exit Firefox button.      %1$s will be replaced
@@ -462,3 +522,4 @@ msgstr "按下 $IMAGE 前往 %1$s 主页、搜索、设置及更多"
 msgctxt "hint_press_menu_to_open_overlay_a11y"
 msgid "Press the menu button for %1$s Home, search, settings, and more"
 msgstr "按下菜单按钮前往 %1$s 主页、搜索、设置及更多"
+


### PR DESCRIPTION
@Delphine for the MVP of this feature, these strings are only going out to EN-US users.  We will need these strings translated for later versions, but they aren't particularly time sensitive.